### PR TITLE
Add workqueue depth metrics for chains in runs-to-csv.sh

### DIFF
--- a/tools/runs-to-csv.sh
+++ b/tools/runs-to-csv.sh
@@ -61,7 +61,8 @@ find . -name benchmark-tekton.json -print0 | while IFS= read -r -d '' filename; 
         .measurements.apiserver.cpu.mean,
         .measurements.apiserver.memory.mean,
         .measurements."kube-apiserver".cpu.mean,
-        .measurements."kube-apiserver".memory.mean
+        .measurements."kube-apiserver".memory.mean,
+        .measurements.tekton_tekton_chains_controller_workqueue_depth.mean
         ] | @csv' \
         && rc=0 || rc=1
     if [[ "$rc" -ne 0 ]]; then

--- a/tools/runs-to-csv.sh
+++ b/tools/runs-to-csv.sh
@@ -47,6 +47,7 @@ find . -name benchmark-tekton.json -print0 | while IFS= read -r -d '' filename; 
         .measurements."tekton-operator-proxy-webhook".memory.mean,
         .measurements."tekton-operator-proxy-webhook".memory.max,
         .measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean,
+        .measurements.tekton_tekton_chains_controller_workqueue_depth.mean,
         .measurements.tekton_pipelines_controller_running_taskruns_throttled_by_node.mean,
         .measurements.tekton_pipelines_controller_running_taskruns_throttled_by_quota.mean,
         .measurements.tekton_pipelines_controller_client_latency_average.mean,
@@ -61,8 +62,7 @@ find . -name benchmark-tekton.json -print0 | while IFS= read -r -d '' filename; 
         .measurements.apiserver.cpu.mean,
         .measurements.apiserver.memory.mean,
         .measurements."kube-apiserver".cpu.mean,
-        .measurements."kube-apiserver".memory.mean,
-        .measurements.tekton_tekton_chains_controller_workqueue_depth.mean
+        .measurements."kube-apiserver".memory.mean
         ] | @csv' \
         && rc=0 || rc=1
     if [[ "$rc" -ne 0 ]]; then


### PR DESCRIPTION
Added `.measurements.tekton_tekton_chains_controller_workqueue_depth.mean` to _runs-to-csv.sh_ script. 