### PR TITLE
SRVKP-4312 added test scenario for benchmarking baseline+bigbang scen…

### DIFF
--- a/ci-scripts/load-test.sh
+++ b/ci-scripts/load-test.sh
@@ -27,6 +27,11 @@ kubectl apply -f "$TEST_PIPELINE"
 
 info "Benchmark ${TEST_TOTAL} | ${TEST_CONCURRENT} | ${TEST_RUN}"
 before=$(date -Ins --utc)
+if [ -n "$WAIT_TIME" ]; then
+    info "Waiting to establish a baseline performance before creating PRs/TRs"
+    sleep $WAIT_TIME
+    info "Wait timeout completed"
+fi
 time ../../tools/benchmark.py --insecure --total "${TEST_TOTAL}" --concurrent "${TEST_CONCURRENT}" --run "${TEST_RUN}" --stats-file benchmark-stats.csv --output-file benchmark-output.json --verbose $TEST_PARAMS
 after=$(date -Ins --utc)
 time ../../tools/stats.sh "$before" "$after"

--- a/tests/scaling-pipelines/scenario/common/lib.sh
+++ b/tests/scaling-pipelines/scenario/common/lib.sh
@@ -252,3 +252,13 @@ function wait_for_prs_finished() {
         sleep 10
     done
 }
+
+function wait_for_timeout() {
+    # Wait until a certain timeout
+    local timeout="$1"
+    local message="$2"
+
+    info "Waiting for $timeout seconds timeout to '$message'"
+    sleep $timeout
+    info "Timeout completed."
+}

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/README.md
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/README.md
@@ -1,6 +1,6 @@
 # "signing-tr-tekton-bigbang-with-baseline" scenario
 
-This scenario is used to establishe a baseline performnace by:
+This scenario is used to establish a baseline performance by:
 1. Monitoring the cluster for $WAIT_TIME duration without any load.
 2. Creating PRs/TRs and analyze the load for another $WAIT_TIME duration.
 3. Enable Chains to analyze chains controller usage and metrics.

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/README.md
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/README.md
@@ -1,0 +1,10 @@
+# "signing-tr-tekton-bigbang-with-baseline" scenario
+
+This scenario is used to establishe a baseline performnace by:
+1. Monitoring the cluster for $WAIT_TIME duration without any load.
+2. Creating PRs/TRs and analyze the load for another $WAIT_TIME duration.
+3. Enable Chains to analyze chains controller usage and metrics.
+
+This scenario runs on downstream only.
+
+> Make sure to set WAIT_TIME environment variable to duration of waiting time (in seconds).

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/pipeline.yaml
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/pipeline.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: echo
+spec:
+  description: "Just hello world task"
+  params: []
+  results: []
+  steps:
+    - name: echo
+      image: registry.redhat.io/ubi8/ubi-minimal@sha256:574f201d7ed185a9932c91cef5d397f5298dff9df08bc2ebb266c6d1e6284cd1
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "Hello World"
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: echo
+spec:
+  params: []
+  tasks:
+    - name: echo
+      taskRef:
+        name: echo
+      params: []

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/run.yaml
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/run.yaml
@@ -1,0 +1,9 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: echo-
+spec:
+  pipelineRef:
+    name: echo
+  params: []
+  workspaces: []

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/setup.sh
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/setup.sh
@@ -1,0 +1,18 @@
+source scenario/common/lib.sh
+
+WAIT_TIME="${WAIT_TIME:-1200}"
+
+chains_setup_tekton_tekton_
+
+chains_stop
+
+(
+    wait_for_prs_finished "${TEST_TOTAL}"
+    
+    # Wait before starting chains to establish baseline with PRs/TRs
+    wait_for_timeout $WAIT_TIME "establish baseline performance with PRs/TRs"
+
+    chains_start
+) &
+
+export TEST_PARAMS="--wait-for-state signed_true"

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/tierdown.sh
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-with-baseline/tierdown.sh
@@ -1,0 +1,3 @@
+source scenario/common/lib.sh
+
+set_ended_now


### PR DESCRIPTION
# Changes

-  Added a new test scenario "signing-tr-tekton-bigbang-with-baseline"
-  Introduced a new environment variable **WAIT_TIME** (time duration in seconds) that will enable waiting time before starting chains. The same variable is used in the newly added test scenario to wait before starting chains.

## "signing-tr-tekton-bigbang-with-baseline" scenario

This scenario is used to establish a baseline performance by:
1. Monitoring the cluster for $WAIT_TIME duration without any load.
2. Creating PRs/TRs and analyze the load for another $WAIT_TIME duration.
3. Enable Chains to analyze chains controller usage and metrics.

