### PR TITLE
fixed issue with unbound local variable

### DIFF
--- a/ci-scripts/load-test.sh
+++ b/ci-scripts/load-test.sh
@@ -27,7 +27,7 @@ kubectl apply -f "$TEST_PIPELINE"
 
 info "Benchmark ${TEST_TOTAL} | ${TEST_CONCURRENT} | ${TEST_RUN}"
 before=$(date -Ins --utc)
-if [ -n "$WAIT_TIME" ]; then
+if [ -n "${WAIT_TIME:-}" ]; then
     info "Waiting to establish a baseline performance before creating PRs/TRs"
     sleep $WAIT_TIME
     info "Wait timeout completed"


### PR DESCRIPTION
As the _load-test.sh_ script is setting `set -o nounset`, this makes bash to throw errors for all unbound variables. So added default null value for WAIT_TIME flag.