### PR TITLE
Add pruner settings and test scenario for evaluating baseline performance with pruner and chains.

### DIFF
--- a/tests/scaling-pipelines/scenario/common/lib.sh
+++ b/tests/scaling-pipelines/scenario/common/lib.sh
@@ -92,6 +92,16 @@ function chains_stop() {
     kubectl patch TektonConfig/config --type='merge' -p='{"spec":{"chain":{"disabled": true}}}'
 }
 
+function pruner_start() {
+    info "Enabling Pruner"
+    kubectl patch TektonConfig config --type merge --patch "{\"spec\":{\"pruner\":{\"disabled\": false,\"resources\":[\"taskrun\", \"pipelinerun\"],\"schedule\":\"${PRUNER_SCHEDULE:-* * * * *}\",\"keep\":${PRUNER_KEEP:-3},\"prune-per-resource\":${PRUNE_PER_RESOURCE:-true}}}}"
+}
+
+function pruner_stop() {
+    info "Disabling Pruner"
+    kubectl patch TektonConfig/config --type='merge' -p='{"spec":{"pruner":{"disabled": true}}}'
+}
+
 function internal_registry_setup() {
     info "Setting up internal registry"
 

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/README.md
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/README.md
@@ -1,0 +1,11 @@
+# "signing-tr-tekton-with-pruner" scenario
+
+This scenario is supposed to stress Pipelines, Chains controller and pruner while still creating more PRs and TRs, signing just PipelineRuns and TaskRuns, no artifacts involved.
+
+This scenario is used to establish a baseline performance by:
+1. Monitoring the cluster for $WAIT_TIME duration without any load.
+2. Creating PRs/TRs and analyze the load for another $EVENT_TIMEOUT duration.
+3. Enable Pruner and analyze the cluster performance for $EVENT_TIMEOUT duration.
+4. Enable Chains and analyze the cluster performance for $EVENT_TIMEOUT duration to finish the test.
+
+This scenario runs on downstream only.

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/README.md
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/README.md
@@ -1,6 +1,6 @@
 # "signing-tr-tekton-with-pruner" scenario
 
-This scenario is supposed to stress Pipelines, Chains controller and pruner while still creating more PRs and TRs, signing just PipelineRuns and TaskRuns, no artifacts involved.
+This scenario is supposed to stress Pipelines, Chains controller and pruner while still creating more PRs and TRs, signing just PipelineRuns and TaskRuns.
 
 This scenario is used to establish a baseline performance by:
 1. Monitoring the cluster for $WAIT_TIME duration without any load.

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/pipeline.yaml
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/pipeline.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: echo
+spec:
+  description: "Just hello world task"
+  params: []
+  results: []
+  steps:
+    - name: echo
+      image: registry.redhat.io/ubi8/ubi-minimal@sha256:574f201d7ed185a9932c91cef5d397f5298dff9df08bc2ebb266c6d1e6284cd1
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        echo "Hello World"
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: echo
+spec:
+  params: []
+  tasks:
+    - name: echo
+      taskRef:
+        name: echo
+      params: []

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/run.yaml
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/run.yaml
@@ -1,0 +1,9 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: echo-
+spec:
+  pipelineRef:
+    name: echo
+  params: []
+  workspaces: []

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/setup.sh
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/setup.sh
@@ -1,0 +1,23 @@
+source scenario/common/lib.sh
+
+# timeout between events (pruner start/chains start) [Default: 20 mins]
+EVENT_IDLE_TIMEOUT=$(expr ${EVENT_TIMEOUT:-20} \* 60) 
+
+# Total time for running the test = Wait Time + Pruner Start + Chains Start + Event Timeout (buffer)
+TOTAL_TIMEOUT=$(expr ${WAIT_TIME:-0} \* 60 + 3 \* ${EVENT_IDLE_TIMEOUT})
+
+chains_setup_tekton_tekton_
+
+chains_stop
+
+pruner_stop
+
+(
+    wait_for_timeout $EVENT_IDLE_TIMEOUT "establish baseline performance with PRs/TRs"
+    pruner_start
+    wait_for_timeout $EVENT_IDLE_TIMEOUT "establish baseline performance with PRs/TRs"
+    chains_start
+) &
+
+# Stop if all the PRs are signed or until timeout (32 mins)
+export TEST_PARAMS="--wait-for-duration=${TOTAL_TIMEOUT}"

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/setup.sh
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/setup.sh
@@ -1,10 +1,10 @@
 source scenario/common/lib.sh
 
 # timeout between events (pruner start/chains start) [Default: 20 mins]
-EVENT_IDLE_TIMEOUT=$(expr ${EVENT_TIMEOUT:-20} \* 60) 
+EVENT_IDLE_TIMEOUT=${EVENT_TIMEOUT:-$(expr 20 \* 60)}
 
-# Total time for running the test = Wait Time + Pruner Start + Chains Start + Event Timeout (buffer)
-TOTAL_TIMEOUT=$(expr ${WAIT_TIME:-0} \* 60 + 3 \* ${EVENT_IDLE_TIMEOUT})
+# Total time for running the test = Wait Time + Pruner Start + Chains Start + Event Timeout (end buffer)
+TOTAL_TIMEOUT=$(expr ${WAIT_TIME:-0} + 3 \* ${EVENT_IDLE_TIMEOUT})
 
 chains_setup_tekton_tekton_
 
@@ -19,5 +19,5 @@ pruner_stop
     chains_start
 ) &
 
-# Stop if all the PRs are signed or until timeout (32 mins)
+# Stop the execution after total timeout duration
 export TEST_PARAMS="--wait-for-duration=${TOTAL_TIMEOUT}"

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/tierdown.sh
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-with-pruner/tierdown.sh
@@ -1,0 +1,3 @@
+source scenario/common/lib.sh
+
+set_ended_now


### PR DESCRIPTION
## Added:

- Functions to start/stop pruner with customizable env configs:
    - **PRUNER_SCHEDULE**: Schedule to run pruner (Default: * * * * *)
    - **PRUNER_KEEP**:  Number of PRs/TRs to retain (Default: 3)
    - **PRUNE_PER_RESOURCE**: Configure pruner per resource type (Default: true)
- New test scenario **signing-tr-tekton-with-pruner** to evaluate ongoing bigbang scenario for simple hello-world program with pruner options enabled.
    - The test scenario sets total run value to 1,000,000 pipeline runs and evaluates the performance until specific amount of duration (seconds) mentioned in `--wait-for-duration` flag.
    - Introduced **EVENT_TIMEOUT** env variable to set duration (seconds) for setting idle timeout between the events - pr run, pruner start and chains start.
