### PR TITLE
feat(SRVKP-4471): Added new stat for capturing terminated status in benchmark script

### DIFF
--- a/tools/visualize-benchmark-stats.sh
+++ b/tools/visualize-benchmark-stats.sh
@@ -27,7 +27,7 @@ data_file="${1}"
     echo -n " '$data_file' using 2:7 title 'prs_finished' linewidth 2,"
     echo -n " '$data_file' using 2:8 title 'prs_signed_true' linewidth 2,"
     echo -n " '$data_file' using 2:10 title 'prs_finalizers_present' linewidth 2,"
-    echo -n " '$data_file' using 2:14 title 'prs_terminated' linewidth 2,"
+    echo -n " '$data_file' using 2:14 title 'prs_deleted' linewidth 2,"
 } | gnuplot
 
 {
@@ -51,5 +51,5 @@ data_file="${1}"
     echo -n " '$data_file' using 2:18 title 'trs_finished' linewidth 2,"
     echo -n " '$data_file' using 2:19 title 'trs_signed_true' linewidth 2,"
     echo -n " '$data_file' using 2:21 title 'trs_finalizers_present' linewidth 2,"
-    echo -n " '$data_file' using 2:23 title 'trs_terminated' linewidth 2,"
+    echo -n " '$data_file' using 2:23 title 'trs_deleted' linewidth 2,"
 } | gnuplot

--- a/tools/visualize-benchmark-stats.sh
+++ b/tools/visualize-benchmark-stats.sh
@@ -27,6 +27,7 @@ data_file="${1}"
     echo -n " '$data_file' using 2:7 title 'prs_finished' linewidth 2,"
     echo -n " '$data_file' using 2:8 title 'prs_signed_true' linewidth 2,"
     echo -n " '$data_file' using 2:10 title 'prs_finalizers_present' linewidth 2,"
+    echo -n " '$data_file' using 2:14 title 'prs_terminated' linewidth 2,"
 } | gnuplot
 
 {
@@ -44,10 +45,11 @@ data_file="${1}"
         set ylabel 'Count'
         set output 'benchmark-stats-taskrunsruns.png'
         plot"
-    echo -n " '$data_file' using 2:14 title 'trs_total' linewidth 2,"
-    echo -n " '$data_file' using 2:15 title 'trs_pending' linewidth 2,"
-    echo -n " '$data_file' using 2:16 title 'trs_running' linewidth 2,"
-    echo -n " '$data_file' using 2:17 title 'trs_finished' linewidth 2,"
-    echo -n " '$data_file' using 2:18 title 'trs_signed_true' linewidth 2,"
-    echo -n " '$data_file' using 2:20 title 'trs_finalizers_present' linewidth 2,"
+    echo -n " '$data_file' using 2:15 title 'trs_total' linewidth 2,"
+    echo -n " '$data_file' using 2:16 title 'trs_pending' linewidth 2,"
+    echo -n " '$data_file' using 2:17 title 'trs_running' linewidth 2,"
+    echo -n " '$data_file' using 2:18 title 'trs_finished' linewidth 2,"
+    echo -n " '$data_file' using 2:19 title 'trs_signed_true' linewidth 2,"
+    echo -n " '$data_file' using 2:21 title 'trs_finalizers_present' linewidth 2,"
+    echo -n " '$data_file' using 2:23 title 'trs_terminated' linewidth 2,"
 } | gnuplot


### PR DESCRIPTION
This PR introduces the following change:
- Add **terminated** measurement in `benchmark-stats.csv` output for pipelineruns and taskruns. This measurement is calculated by looking up  *.metadata.deletionTimestamp* flag in the object event definition.
- Update *visualize-benchmark-stats.sh* to incorporate new header ordering from adding **terminated** stats. 