### PR TITLE
feat(SRVKP-4471): Add "terminated" measurement based on .metadata.deletionTimestamp field

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -350,6 +350,12 @@ def process_events_thread(watcher, data, lock):
             else:
                 data[e_name]["deleted"] = False
 
+            # Determine terminated status
+            if "deletionTimestamp" in data[e_name]:
+                data[e_name]["terminated"] = True
+            else:
+                data[e_name]["terminated"] = False
+
 
 class PropagatingThread(threading.Thread):
     def run(self):
@@ -426,6 +432,9 @@ def counter_thread(args, pipelineruns, pipelineruns_lock, taskruns, taskruns_loc
             deleted = len(
                 [i for i in pipelineruns.values() if i['deleted'] is True]
             )
+            terminated = len(
+                [i for i in pipelineruns.values() if i['terminated'] is True]
+            )
         prs = {
             "monitoring_start": monitoring_start,
             "monitoring_now": monitoring_now,
@@ -439,6 +448,7 @@ def counter_thread(args, pipelineruns, pipelineruns_lock, taskruns, taskruns_loc
             "finalizers_present": finalizers_present,
             "finalizers_absent": finalizers_absent,
             "deleted": deleted,
+            "terminated": terminated,
         }
 
         if args.concurrent > 0:
@@ -478,6 +488,9 @@ def counter_thread(args, pipelineruns, pipelineruns_lock, taskruns, taskruns_loc
             deleted = len(
                 [i for i in taskruns.values() if i['deleted'] is True]
             )
+            terminated = len(
+                [i for i in taskruns.values() if i['terminated'] is True]
+            )
         trs = {
             "monitoring_start": monitoring_start,
             "monitoring_now": monitoring_now,
@@ -491,6 +504,7 @@ def counter_thread(args, pipelineruns, pipelineruns_lock, taskruns, taskruns_loc
             "finalizers_present": finalizers_present,
             "finalizers_absent": finalizers_absent,
             "deleted": deleted,
+            "terminated": terminated,
         }
 
         if monitoring_second > args.delay and prs["should_be_started"] > 0:
@@ -543,6 +557,7 @@ def counter_thread(args, pipelineruns, pipelineruns_lock, taskruns, taskruns_loc
                             "prs_started_worked",
                             "prs_started_failed",
                             "prs_deleted",
+                            "prs_terminated",
                             "trs_total",
                             "trs_pending",
                             "trs_running",
@@ -552,6 +567,7 @@ def counter_thread(args, pipelineruns, pipelineruns_lock, taskruns, taskruns_loc
                             "trs_finalizers_present",
                             "trs_finalizers_absent",
                             "trs_deleted",
+                            "trs_terminated",
                         ]
                     )
             with open(args.stats_file, "a") as fd:
@@ -572,6 +588,7 @@ def counter_thread(args, pipelineruns, pipelineruns_lock, taskruns, taskruns_loc
                         prs["started_worked"],
                         prs["started_failed"],
                         prs["deleted"],
+                        prs['terminated'],
                         trs["total"],
                         trs["pending"],
                         trs["running"],
@@ -581,6 +598,7 @@ def counter_thread(args, pipelineruns, pipelineruns_lock, taskruns, taskruns_loc
                         trs["finalizers_present"],
                         trs["finalizers_absent"],
                         trs["deleted"],
+                        trs['terminated'],
                     ]
                 )
 

--- a/tools/visualize-benchmark-stats.sh
+++ b/tools/visualize-benchmark-stats.sh
@@ -27,7 +27,7 @@ data_file="${1}"
     echo -n " '$data_file' using 2:7 title 'prs_finished' linewidth 2,"
     echo -n " '$data_file' using 2:8 title 'prs_signed_true' linewidth 2,"
     echo -n " '$data_file' using 2:10 title 'prs_finalizers_present' linewidth 2,"
-    echo -n " '$data_file' using 2:14 title 'prs_terminated' linewidth 2,"
+    echo -n " '$data_file' using 2:14 title 'prs_deleted' linewidth 2,"
 } | gnuplot
 
 {
@@ -51,5 +51,5 @@ data_file="${1}"
     echo -n " '$data_file' using 2:18 title 'trs_finished' linewidth 2,"
     echo -n " '$data_file' using 2:19 title 'trs_signed_true' linewidth 2,"
     echo -n " '$data_file' using 2:21 title 'trs_finalizers_present' linewidth 2,"
-    echo -n " '$data_file' using 2:23 title 'trs_terminated' linewidth 2,"
+    echo -n " '$data_file' using 2:23 title 'trs_deleted' linewidth 2,"
 } | gnuplot

--- a/tools/visualize-benchmark-stats.sh
+++ b/tools/visualize-benchmark-stats.sh
@@ -27,6 +27,7 @@ data_file="${1}"
     echo -n " '$data_file' using 2:7 title 'prs_finished' linewidth 2,"
     echo -n " '$data_file' using 2:8 title 'prs_signed_true' linewidth 2,"
     echo -n " '$data_file' using 2:10 title 'prs_finalizers_present' linewidth 2,"
+    echo -n " '$data_file' using 2:14 title 'prs_terminated' linewidth 2,"
 } | gnuplot
 
 {
@@ -44,10 +45,11 @@ data_file="${1}"
         set ylabel 'Count'
         set output 'benchmark-stats-taskrunsruns.png'
         plot"
-    echo -n " '$data_file' using 2:14 title 'trs_total' linewidth 2,"
-    echo -n " '$data_file' using 2:15 title 'trs_pending' linewidth 2,"
-    echo -n " '$data_file' using 2:16 title 'trs_running' linewidth 2,"
-    echo -n " '$data_file' using 2:17 title 'trs_finished' linewidth 2,"
-    echo -n " '$data_file' using 2:18 title 'trs_signed_true' linewidth 2,"
-    echo -n " '$data_file' using 2:20 title 'trs_finalizers_present' linewidth 2,"
+    echo -n " '$data_file' using 2:15 title 'trs_total' linewidth 2,"
+    echo -n " '$data_file' using 2:16 title 'trs_pending' linewidth 2,"
+    echo -n " '$data_file' using 2:17 title 'trs_running' linewidth 2,"
+    echo -n " '$data_file' using 2:18 title 'trs_finished' linewidth 2,"
+    echo -n " '$data_file' using 2:19 title 'trs_signed_true' linewidth 2,"
+    echo -n " '$data_file' using 2:21 title 'trs_finalizers_present' linewidth 2,"
+    echo -n " '$data_file' using 2:23 title 'trs_terminated' linewidth 2,"
 } | gnuplot

--- a/tools/visualize-benchmark-stats.sh
+++ b/tools/visualize-benchmark-stats.sh
@@ -28,6 +28,7 @@ data_file="${1}"
     echo -n " '$data_file' using 2:8 title 'prs_signed_true' linewidth 2,"
     echo -n " '$data_file' using 2:10 title 'prs_finalizers_present' linewidth 2,"
     echo -n " '$data_file' using 2:14 title 'prs_deleted' linewidth 2,"
+    echo -n " '$data_file' using 2:15 title 'prs_terminated' linewidth 2,"
 } | gnuplot
 
 {
@@ -45,11 +46,12 @@ data_file="${1}"
         set ylabel 'Count'
         set output 'benchmark-stats-taskrunsruns.png'
         plot"
-    echo -n " '$data_file' using 2:15 title 'trs_total' linewidth 2,"
-    echo -n " '$data_file' using 2:16 title 'trs_pending' linewidth 2,"
-    echo -n " '$data_file' using 2:17 title 'trs_running' linewidth 2,"
-    echo -n " '$data_file' using 2:18 title 'trs_finished' linewidth 2,"
-    echo -n " '$data_file' using 2:19 title 'trs_signed_true' linewidth 2,"
-    echo -n " '$data_file' using 2:21 title 'trs_finalizers_present' linewidth 2,"
-    echo -n " '$data_file' using 2:23 title 'trs_deleted' linewidth 2,"
+    echo -n " '$data_file' using 2:16 title 'trs_total' linewidth 2,"
+    echo -n " '$data_file' using 2:17 title 'trs_pending' linewidth 2,"
+    echo -n " '$data_file' using 2:18 title 'trs_running' linewidth 2,"
+    echo -n " '$data_file' using 2:19 title 'trs_finished' linewidth 2,"
+    echo -n " '$data_file' using 2:20 title 'trs_signed_true' linewidth 2,"
+    echo -n " '$data_file' using 2:22 title 'trs_finalizers_present' linewidth 2,"
+    echo -n " '$data_file' using 2:24 title 'trs_deleted' linewidth 2,"
+    echo -n " '$data_file' using 2:25 title 'trs_terminated' linewidth 2,"
 } | gnuplot


### PR DESCRIPTION
- Add **terminated** measurement in *benchmark-stats.csv* output for pipelineruns and taskruns. This measurement is calculated by looking up *.metadata.deletionTimestamp* flag in the object event definition.
- Update *visualize-benchmark-stats.sh* to incorporate new header ordering from adding **terminated** stats.