### PR TITLE
feat(SRVKP-4548): Update Jinja2 test template to support multi-task runs

### DIFF
--- a/tests/scaling-pipelines/scenario/common/lib.sh
+++ b/tests/scaling-pipelines/scenario/common/lib.sh
@@ -181,7 +181,7 @@ function measure_signed_wait() {
 function measure_signed_start() {
     expecte="${1:-$TEST_TOTAL}"
     info "Starting benchmark.py (with 0 concurrent tasks) to monitor signatures"
-    ../../tools/benchmark.py --insecure --namespace $TEST_NAMESPACE --total $TEST_TOTAL --concurrent 0 --wait-for-state signed_true --stats-file benchmark-stats.csv --verbose &
+    ../../tools/benchmark.py --insecure --namespace "${TEST_NAMESPACE:-1}" --total $TEST_TOTAL --concurrent 0 --wait-for-state signed_true --stats-file benchmark-stats.csv --verbose &
     measure_signed_pid=$!
     echo "$measure_signed_pid" >./measure-signed.pid
     debug "Started benchmark.py with PID $measure_signed_pid"
@@ -242,7 +242,7 @@ function wait_for_prs_finished() {
     local target="$1"
     local last_row=""
     local prs_finished=""
-    local namespace="${TEST_NAMESPACE}"
+    local namespace="${TEST_NAMESPACE:-1}"
     info "Waiting for $target finished PipelineRuns"
     while true; do
         if [ -r benchmark-stats.csv ]; then

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-tr-multi-steps/pipeline.yaml.j2
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-tr-multi-steps/pipeline.yaml.j2
@@ -1,8 +1,9 @@
+{% for task_idx in range(1, (task_count or 5) + 1) %}
 ---
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: echo
+  name: echo{{task_idx}}
 spec:
   description: "Just hello world task"
   params: []
@@ -15,9 +16,10 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
         {%- for line_idx in range(1, (line_count or 15) + 1) %}
-        echo "Hello World Chains Performance Benchmark Test {{ (idx - 1) * (line_count or 15) + line_idx }}"{% endfor %}
+        echo "Hello World Chains Performance Benchmark Test {{ (idx - 1) * (line_count or 15) + line_idx }} from Task{{task_idx}}"{% endfor %}
 
     {% endfor %}
+{% endfor %}
 ---
 apiVersion: tekton.dev/v1
 kind: Pipeline
@@ -26,7 +28,9 @@ metadata:
 spec:
   params: []
   tasks:
-    - name: echo
+  {% for task_idx in range(1, (task_count or 5) + 1) %}
+    - name: echo{{task_idx}}
       taskRef:
-        name: echo
+        name: echo{{task_idx}}
       params: []
+  {% endfor %}

--- a/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-tr-multi-steps/setup.sh
+++ b/tests/scaling-pipelines/scenario/signing-tr-tekton-bigbang-tr-multi-steps/setup.sh
@@ -1,6 +1,7 @@
 source scenario/common/lib.sh
 
 # Test Scenario specific env variables
+TEST_BIGBANG_MULTI_STEP__TASK_COUNT="${TEST_BIGBANG_MULTI_STEP__TASK_COUNT:-5}"
 TEST_BIGBANG_MULTI_STEP__STEP_COUNT="${TEST_BIGBANG_MULTI_STEP__STEP_COUNT:-10}"
 TEST_BIGBANG_MULTI_STEP__LINE_COUNT="${TEST_BIGBANG_MULTI_STEP__LINE_COUNT:-15}"
 
@@ -8,4 +9,4 @@ chains_setup_tekton_tekton_
 
 chains_stop
 
-create_pipeline_from_j2_template pipeline.yaml.j2 "step_count=${TEST_BIGBANG_MULTI_STEP__STEP_COUNT}, line_count=${TEST_BIGBANG_MULTI_STEP__LINE_COUNT}"
+create_pipeline_from_j2_template pipeline.yaml.j2 "task_count=${TEST_BIGBANG_MULTI_STEP__TASK_COUNT}, step_count=${TEST_BIGBANG_MULTI_STEP__STEP_COUNT}, line_count=${TEST_BIGBANG_MULTI_STEP__LINE_COUNT}"

--- a/tools/create-pipeline-yaml.py
+++ b/tools/create-pipeline-yaml.py
@@ -47,11 +47,11 @@ def convert_jinja2_filename(j2_template_name:str):
 def process_extra_data_argument(extra_data_arg:str):
     extra_data = {}
     for kv_pair in extra_data_arg.split(","):
-        for kv in kv_pair.split("="):
-            # Remove trailing white-spaces
-            key = kv[0].strip()
-            val = kv[1].strip()
-            extra_data[key] = val
+        kv = kv_pair.split("=")
+        # Remove trailing white-spaces
+        key = kv[0].strip()
+        val = kv[1].strip()
+        extra_data[key] = val
     return extra_data
 
 def populate_and_save_j2_template(args):

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -3,6 +3,8 @@
 started="$1"
 ended="$2"
 
+TEST_NAMESPACE="${TEST_NAMESPACE:-1}"
+
 echo "$(date -Ins --utc) dumping basic results to data files"
 output="benchmark-tekton.json"
 cat <<EOF >$output


### PR DESCRIPTION
- Updated test template for **signing-tr-tekton-bigbang-tr-multi-steps** scenario to include *task_count* parameter which sets the number of taskruns for test pipelines.
- Fixes: Resolves an issue with test scripts when TEST_NAMESPACE is not configured to default value 1 explicitly.