### PR TITLE
fix(SRVKP-5598): Disable chains during cluster setup

### DIFF
--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -166,6 +166,9 @@ EOF
         kubectl patch TektonConfig/config --type merge --patch '{"spec":{"chain":{"options":{"deployments":{"tekton-chains-controller":{"spec":{"template":{"spec":{"containers":[{"name":"tekton-chains-controller","args":['$chains_perf_options']}]}}}}}}}}}'
     fi
 
+    info "Disable Chains"
+    kubectl patch TektonConfig/config --type merge --patch '{"spec":{"chain":{"disabled":true}}}'
+
     info "Disable pruner"
     kubectl patch TektonConfig/config --type merge --patch '{"spec":{"pruner":{"disabled":true}}}'
 


### PR DESCRIPTION
Chains setup is handled across tests individually in its `setup.sh`. To keep consistency between the initialization, only pipelines will be enabled as part of the cluster setup while keeping the chains and pruner disabled.