### PR TITLE
test(SRVKP-5600): Updated readme instruction for testing OpenShift 1.15 + fixed issue with benchmark_stats field change

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want to run the test manually, you will need these tools:
 Setup the OpenShift cluster (assuming `oc login ...` happened already):
 
     export DEPLOYMENT_TYPE="downstream"
-    export DEPLOYMENT_VERSION="1.14"
+    export DEPLOYMENT_VERSION="1.15"
     export DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS=""
     export DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS=""
     export DEPLOYMENT_PIPELINES_KUBE_API_QPS=""
@@ -22,6 +22,8 @@ Setup the OpenShift cluster (assuming `oc login ...` happened already):
     export DEPLOYMENT_CHAINS_KUBE_API_BURST=""
     export DEPLOYMENT_CHAINS_THREADS_PER_CONTROLLER=""
     export DEPLOYMENT_PIPELINES_CONTROLLER_RESOURCES="1/2Gi/1/2Gi"
+    # export DEPLOYMENT_VERSION="1.14"
+    # export DEPLOYMENT_VERSION="1.13"
     ci-scripts/setup-cluster.sh
 
 Run the test:

--- a/tools/convert-benchmark-stats.py
+++ b/tools/convert-benchmark-stats.py
@@ -43,6 +43,7 @@ column_names = [
     'trs_terminated',
 ]
 
+
 class CSV_Object:
     def __init__(self, path):
         self.load_from_file(path)
@@ -53,7 +54,10 @@ class CSV_Object:
 
             # Fetch Headers
             self.headers = [x.strip() for x in data[0].split(',')]
-            self.header_col2idx = { self.headers[i]:i for i in range(len(self.headers)) }
+            self.header_col2idx = { 
+                self.headers[i]: i
+                for i in range(len(self.headers))
+            }
 
             # Fetch data columns
             data_rows = []
@@ -97,7 +101,8 @@ def main(benchmark_stats_file, out):
     for batch in range(batches):
         # Group by namespaces
 
-        # For last batch, take last nth records based on namespace count as start index (as we could have less number of records)
+        # For last batch, take last nth records based on namespace count as
+        # start index (as we could have less number of records)
         if batch == batches - 1:
             start_idx = n - namespace_count
         else:
@@ -121,7 +126,6 @@ def main(benchmark_stats_file, out):
 
         result_rows.append(result_row)
 
-
     with open(out, 'w', encoding='utf-8') as file_writer:
         file_writer.write(",".join(column_names))
         file_writer.write("\n")
@@ -130,6 +134,7 @@ def main(benchmark_stats_file, out):
             file_writer.write("\n")
         file_writer.flush()
         file_writer.close()
+
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:


### PR DESCRIPTION
- Tested with 1.15 version of OpenShift Pipelines on ClusterBot. Updated readme instruction for deploying the latest v1.15 release.
- Fixed issue where updating field name order in "benchmark-stats.csv" would impact `wait_for_prs_finished` method due to hard coding of column index for lookup. Now column field is calculated upfront based on the column header from the file.