### PR TITLE
fix(SRVKP-5763): Random failures in capturing TaskRun-Pod-creationTimestamp metric

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -262,7 +262,9 @@ def process_events_thread(watcher, data, lock):
         logging.debug(f"Processing event: {json.dumps(event)[:100]}...")
 
         try:
-            e_name = find("object.metadata.name", event)
+            # Generate unique name to avoid duplicates due to same object names in multiple-namespaces
+            e_namespace = find("object.metadata.namespace", event)
+            e_name = e_namespace + "." + find("object.metadata.name", event)
         except KeyError as e:
             logging.warning(f"Missing name in {json.dumps(event)}: {e} => skipping it")
             continue

--- a/tools/compare-TaskRun-Pod-creationTimestamp.py
+++ b/tools/compare-TaskRun-Pod-creationTimestamp.py
@@ -33,14 +33,30 @@ def load_file(fd):
     return data
 
 
+def generate_unique_name_mapping(name, namespace):
+    return "{namespace}.{name}".format(
+        namespace=namespace,
+        name=name
+    )
+
+
 def doit(args, status_data):
     logging.info(f"Processing {args.taskruns_list.name}")
     data_taskruns = {}
     for i in load_file(args.taskruns_list)["items"]:
         try:
-            tr_name = i["metadata"]["name"]
+            # TaskRun Names can be duplicate across multiples namespaces
+            # Combine namespace+taskrun name to generate unique name
+            tr_namespace = i["metadata"]["namespace"]
+            tr_name = generate_unique_name_mapping(
+                name=i["metadata"]["name"],
+                namespace=tr_namespace
+            )
             tr_creationTimestamp = i["metadata"]["creationTimestamp"]
-            tr_podName = i["status"]["podName"]
+            tr_podName = generate_unique_name_mapping(
+                name=i["status"]["podName"],
+                namespace=tr_namespace
+            )
         except KeyError as e:
             logging.warning(f"Missing key details in taskruns list: {e}")
             continue
@@ -56,8 +72,16 @@ def doit(args, status_data):
     data_pods = {}
     for i in load_file(args.pods_list)["items"]:
         try:
-            pod_name = i["metadata"]["name"]
-            pod_tr_name = i["metadata"]["labels"]["tekton.dev/taskRun"]
+            # Generate unique pod name to avoid duplicates across multi-namespace
+            pod_namespace = i["metadata"]["namespace"]
+            pod_name = generate_unique_name_mapping(
+                name=i["metadata"]["name"],
+                namespace=pod_namespace
+            )
+            pod_tr_name = generate_unique_name_mapping(
+                name=i["metadata"]["labels"]["tekton.dev/taskRun"],
+                namespace=pod_namespace,
+            )
             pod_creationTimestamp = i["metadata"]["creationTimestamp"]
         except KeyError as e:
             logging.warning(f"Missing key details in pods list: {e}")

--- a/tools/compare-TaskRun-Pod-creationTimestamp.py
+++ b/tools/compare-TaskRun-Pod-creationTimestamp.py
@@ -33,13 +33,6 @@ def load_file(fd):
     return data
 
 
-def generate_unique_name_mapping(name, namespace):
-    return "{namespace}.{name}".format(
-        namespace=namespace,
-        name=name
-    )
-
-
 def doit(args, status_data):
     logging.info(f"Processing {args.taskruns_list.name}")
     data_taskruns = {}
@@ -48,15 +41,9 @@ def doit(args, status_data):
             # TaskRun Names can be duplicate across multiples namespaces
             # Combine namespace+taskrun name to generate unique name
             tr_namespace = i["metadata"]["namespace"]
-            tr_name = generate_unique_name_mapping(
-                name=i["metadata"]["name"],
-                namespace=tr_namespace
-            )
+            tr_name = f'{tr_namespace}.{i["metadata"]["name"]}'
             tr_creationTimestamp = i["metadata"]["creationTimestamp"]
-            tr_podName = generate_unique_name_mapping(
-                name=i["status"]["podName"],
-                namespace=tr_namespace
-            )
+            tr_podName = f'{tr_namespace}.{i["status"]["podName"]}'
         except KeyError as e:
             logging.warning(f"Missing key details in taskruns list: {e}")
             continue
@@ -74,14 +61,8 @@ def doit(args, status_data):
         try:
             # Generate unique pod name to avoid duplicates across multi-namespace
             pod_namespace = i["metadata"]["namespace"]
-            pod_name = generate_unique_name_mapping(
-                name=i["metadata"]["name"],
-                namespace=pod_namespace
-            )
-            pod_tr_name = generate_unique_name_mapping(
-                name=i["metadata"]["labels"]["tekton.dev/taskRun"],
-                namespace=pod_namespace,
-            )
+            pod_name = f'{pod_namespace}.{i["metadata"]["name"]}'
+            pod_tr_name = f'{pod_namespace}.{i["metadata"]["labels"]["tekton.dev/taskRun"]}'
             pod_creationTimestamp = i["metadata"]["creationTimestamp"]
         except KeyError as e:
             logging.warning(f"Missing key details in pods list: {e}")


### PR DESCRIPTION
**Problem**
It was observed that random test runs were failing when trying to calculate duration for pod creation with the script `tools/compare-TaskRun-Pod-creationTimestamp.py`.

The issue was caused due to conflicting names for PRs/TRs objects that were present across multiple namespaces.

**Changes to resolve the issue**
- `compare-TaskRun-Pod-creationTimestamp.py`: The script now uses a combination of **namespace** and **object name** to create a unique key to represent the PR/TR. 
- `benchmark.py`: One of the test artifacts _benchmark-output.json_ contains a mapping of PRs/TRs object and different state information. The name key used for creating the mapping will lead to same duplicate issue and end up overriding existing information for PRs/TRs objects. Similar fix has been applied to generate an unique key mapping.

