### PR TITLE
feat(SRVKP-6127): Add Installing and Monitoring of Tekton Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Setup the OpenShift cluster (assuming `oc login ...` happened already):
     export DEPLOYMENT_CHAINS_KUBE_API_BURST=""
     export DEPLOYMENT_CHAINS_THREADS_PER_CONTROLLER=""
     export DEPLOYMENT_PIPELINES_CONTROLLER_RESOURCES="1/2Gi/1/2Gi"
+
+    # export INSTALL_RESULTS="true"
+    # export DEPLOYMENT_TYPE_RESULTS="downstream" # "upstream" (Default: downstream)
+    # export DEPLOYMENT_RESULTS_UPSTREAM_VERSION="v0.11.0" # Used only for upstream (Default: latest)
+
     # export DEPLOYMENT_VERSION="1.14"
     # export DEPLOYMENT_VERSION="1.13"
     ci-scripts/setup-cluster.sh

--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -332,8 +332,8 @@ spec:
 EOF
 
         # Wait for tekton-results resources to start
-        kubectl -n $TEKTON_RESULTS_NS wait --for=condition=ready --timeout=300s pod -l app.kubernetes.io/name=tekton-results-api
-        kubectl -n $TEKTON_RESULTS_NS wait --for=condition=ready --timeout=300s pod -l app.kubernetes.io/name=tekton-results-watcher
+        wait_for_entity_by_selector 300 $TEKTON_RESULTS_NS pod app.kubernetes.io/name=tekton-results-api
+        wait_for_entity_by_selector 300 $TEKTON_RESULTS_NS pod app.kubernetes.io/name=tekton-results-watcher
 
         # Setup route to access Results-API endpoint
         # TODO: Should test this with CI setup and also should evaluate how encryption works
@@ -373,8 +373,8 @@ EOF
         fi
 
         # Wait for tekton-results resources to start
-        kubectl -n $TEKTON_RESULTS_NS wait --for=condition=ready --timeout=300s pod -l app.kubernetes.io/name=tekton-results-api
-        kubectl -n $TEKTON_RESULTS_NS wait --for=condition=ready --timeout=300s pod -l app.kubernetes.io/name=tekton-results-watcher
+        wait_for_entity_by_selector 300 $TEKTON_RESULTS_NS pod app.kubernetes.io/name=tekton-results-api
+        wait_for_entity_by_selector 300 $TEKTON_RESULTS_NS pod app.kubernetes.io/name=tekton-results-watcher
 
         # Setup route to access Results-API endpoint
         # TODO: Should test this with CI setup and also should evaluate how encryption works

--- a/config/cluster_read_config.yaml
+++ b/config/cluster_read_config.yaml
@@ -268,3 +268,11 @@
 {{ monitor_pod('openshift-apiserver', 'apiserver', 15) }}
 {{ monitor_pod('openshift-kube-apiserver', 'kube-apiserver', 15, pod_suffix_regex='-ip-.+') }}
 {{ monitor_pod('openshift-etcd', 'etcd', 15, pod_suffix_regex='-ip-.+') }}
+
+
+
+# Collect data for Tekton Results Pods
+{{ monitor_pod('openshift-pipelines', 'tekton-results-api', 15) }}
+{{ monitor_pod('openshift-pipelines', 'tekton-results-watcher', 15) }}
+{{ monitor_pod('tekton-pipelines', 'tekton-results-api', 15) }}
+{{ monitor_pod('tekton-pipelines', 'tekton-results-watcher', 15) }}

--- a/tools/convert-benchmark-stats.py
+++ b/tools/convert-benchmark-stats.py
@@ -30,6 +30,9 @@ column_names = [
     'prs_started_failed',
     'prs_deleted',
     'prs_terminated',
+    "prs_log_present",
+    "prs_result_present",
+    "prs_record_present",
     'trs_total',
     'trs_failed',
     'trs_pending',
@@ -41,6 +44,9 @@ column_names = [
     'trs_finalizers_absent',
     'trs_deleted',
     'trs_terminated',
+    "trs_log_present",
+    "trs_result_present",
+    "trs_record_present",
 ]
 
 


### PR DESCRIPTION
# Changes
- The PR adds support for installing Tekton Results (both downstream/upstream) on OpenShift cluster as part of performance testing cluster setup.
- Introduces the following new environment variables for the Tekton Results setup:
  - **INSTALL_RESULTS**: Whether to install Tekton Results during the cluster setup. 
  (Possible Values: true/false | Default: false)
  - **DEPLOYMENT_TYPE_RESULTS**: Which instance of Tekton Results to install 
  (Possible Values: upstream/downstream | Default: downstream)
  - **DEPLOYMENT_RESULTS_UPSTREAM_VERSION**: Used when **DEPLOYMENT_TYPE_RESULTS** set to *upstream* and specifies which version of upstream Tekton Results to install in cluster. 
  (Values based on official [release](https://github.com/tektoncd/results/releases) | Default: latest)
- Additionally, the PR also adds the monitoring of following pods: **tekton-results-api** and **tekton-results-watcher**