### PR TITLE
feat(SRVKP-6149): New test scenario for evaluating tekton results use-case

### DIFF
--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -323,7 +323,7 @@ spec:
     logging_pvc_name: tekton-logs
     logs_path: /logs
     logs_type: File
-    logs_buffer_size: 32768
+    logs_buffer_size: 2097152
     auth_disable: true
     tls_hostname_override: tekton-results-api-service.$TEKTON_RESULTS_NS.svc.cluster.local
     db_enable_auto_migration: true

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/.gitignore
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/.gitignore
@@ -1,0 +1,1 @@
+pipeline.yaml

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/README.md
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/README.md
@@ -1,0 +1,16 @@
+# "timebased-sign-pruner" scenario
+
+This scenario is supposed to stress Pipelines, Chains controller and Pruner by creating PR/TR at constant rate.
+
+The following environment variables are available for controlling timeouts:
+- **TOTAL_TIMEOUT**: Total time for test execution (Default: 2 hours)
+- **CHAINS_WAIT_TIME**: Wait period before enabling chains (Default: 10 mins)
+- **PRUNER_WAIT_TIME**: Wait period before enabling pruner (Default: 10 mins)
+
+The following environment variables are available for controlling the PR/TR payload size and log outputs:
+- **TEST_BIGBANG_MULTI_STEP__TASK_COUNT**: Total number of tasks per Pipeline (Default: 5 tasks)
+- **TEST_BIGBANG_MULTI_STEP__STEP_COUNT**: Total number of steps per Task (Default: 10 steps)
+- **TEST_BIGBANG_MULTI_STEP__LINE_COUNT**: Total number of unique output log lines per step (Default: 15 lines)
+
+
+This scenario **supports** multi-namespace testing through *TEST_NAMESPACE* env variable.

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/pipeline.yaml.j2
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/pipeline.yaml.j2
@@ -1,0 +1,36 @@
+{% for task_idx in range(1, (task_count or 5) + 1) %}
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: echo{{task_idx}}
+spec:
+  description: "Just hello world task"
+  params: []
+  results: []
+  steps:
+    {% for idx in range(1, (step_count or 10) + 1) %}
+    - name: echo{{ idx }}
+      image: registry.redhat.io/ubi8/ubi-minimal@sha256:574f201d7ed185a9932c91cef5d397f5298dff9df08bc2ebb266c6d1e6284cd1
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        {%- for line_idx in range(1, (line_count or 15) + 1) %}
+        echo "Hello World Chains Performance Benchmark Test {{ (idx - 1) * (line_count or 15) + line_idx }} from Task{{task_idx}}"{% endfor %}
+
+    {% endfor %}
+{% endfor %}
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: echo
+spec:
+  params: []
+  tasks:
+  {% for task_idx in range(1, (task_count or 5) + 1) %}
+    - name: echo{{task_idx}}
+      taskRef:
+        name: echo{{task_idx}}
+      params: []
+  {% endfor %}

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/run.yaml
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/run.yaml
@@ -1,0 +1,9 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: echo-
+spec:
+  pipelineRef:
+    name: echo
+  params: []
+  workspaces: []

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/setup.sh
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/setup.sh
@@ -1,0 +1,38 @@
+source scenario/common/lib.sh
+
+# Test Scenario specific env variables
+TEST_BIGBANG_MULTI_STEP__TASK_COUNT="${TEST_BIGBANG_MULTI_STEP__TASK_COUNT:-5}"
+TEST_BIGBANG_MULTI_STEP__STEP_COUNT="${TEST_BIGBANG_MULTI_STEP__STEP_COUNT:-10}"
+TEST_BIGBANG_MULTI_STEP__LINE_COUNT="${TEST_BIGBANG_MULTI_STEP__LINE_COUNT:-15}"
+
+# Total time for test execution [Default: 2 hours]
+TOTAL_TIMEOUT=${TOTAL_TIMEOUT:-7200} 
+
+# Wait period before enabling chains/pruner
+# Values should be less than TOTAL_TIMEOUT to enable the components for the test.
+CHAINS_WAIT_TIME=${CHAINS_WAIT_TIME:-600} # [Default: 10 mins]
+PRUNER_WAIT_TIME=${PRUNER_WAIT_TIME:-600} # [Default: 10 mins]
+
+chains_setup_tekton_tekton_
+
+chains_stop
+
+pruner_stop
+
+#  Timeout before enabling Chains 
+(
+    wait_for_timeout $CHAINS_WAIT_TIME "enable Chains"
+    chains_start
+) &
+
+
+#  Timeout before enabling Pruner
+(
+    wait_for_timeout $PRUNER_WAIT_TIME "enable Pruner"
+    pruner_start
+) &
+
+# Stop the execution after total timeout duration
+export TEST_PARAMS="--wait-for-duration=${TOTAL_TIMEOUT}"
+
+create_pipeline_from_j2_template pipeline.yaml.j2 "task_count=${TEST_BIGBANG_MULTI_STEP__TASK_COUNT}, step_count=${TEST_BIGBANG_MULTI_STEP__STEP_COUNT}, line_count=${TEST_BIGBANG_MULTI_STEP__LINE_COUNT}"

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/tierdown.sh
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/tierdown.sh
@@ -1,0 +1,3 @@
+source scenario/common/lib.sh
+
+set_ended_now


### PR DESCRIPTION
## New Test Scenario

The PR adds a new testing scenario for stress testing Tekton Controllers (Pipelines, Chains, Pruner, Results) by constant load of PRs/TRs with log generation.

The following environment variables are available for controlling timeouts:
- **TOTAL_TIMEOUT**: Total time for test execution (Default: 2 hours)
- **CHAINS_WAIT_TIME**: Wait period before enabling chains (Default: 10 mins)
- **PRUNER_WAIT_TIME**: Wait period before enabling pruner (Default: 10 mins)

The following environment variables are available for controlling the PR/TR payload size and log outputs:
- **TEST_BIGBANG_MULTI_STEP__TASK_COUNT**: Total number of tasks per Pipeline (Default: 5 tasks)
- **TEST_BIGBANG_MULTI_STEP__STEP_COUNT**: Total number of steps per Task (Default: 10 steps)
- **TEST_BIGBANG_MULTI_STEP__LINE_COUNT**: Total number of unique output log lines per step (Default: 15 lines)

## Results-API Logs Collector

In addition, the `collect-results.sh` script captures following log files from results-api:
- **results-api-logs.txt**: Raw log file captured from results-api pods.
- **results-api-logs.json**: List of JSON objects that contain GRPC status updates.
- **results-api-logs-parse-errors.txt**: Errors generated during JSON parsing of `results-api-logs.txt`

JIRA: https://issues.redhat.com/browse/SRVKP-6149
