### PR TITLE
feat(SRVKP-6575): Locust Script Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tests/scaling-pipelines/measure-signed.csv
 tests/scaling-pipelines/pipelineruns.json
 tests/scaling-pipelines/pods.json
 tests/scaling-pipelines/taskruns.json
+tests/scaling-pipelines/locust-test.log

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Setup the OpenShift cluster (assuming `oc login ...` happened already):
     # export INSTALL_RESULTS="true"
     # export DEPLOYMENT_TYPE_RESULTS="downstream" # "upstream" (Default: downstream)
     # export DEPLOYMENT_RESULTS_UPSTREAM_VERSION="v0.11.0" # Used only for upstream (Default: latest)
+    # export RUN_LOCUST="true"
 
     # export DEPLOYMENT_VERSION="1.14"
     # export DEPLOYMENT_VERSION="1.13"

--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -29,6 +29,7 @@ mkdir -p "${monitoring_collection_dir}"
 [ -f tests/scaling-pipelines/resolutionrequests.json ] && mv tests/scaling-pipelines/resolutionrequests.json "${ARTIFACT_DIR}/"
 [ -f tests/scaling-pipelines/imagestreamtags.json ] && mv tests/scaling-pipelines/imagestreamtags.json "${ARTIFACT_DIR}/"
 [ -f tests/scaling-pipelines/measure-signed.csv ] && mv tests/scaling-pipelines/measure-signed.csv "${ARTIFACT_DIR}/"
+[ -f tests/scaling-pipelines/locust-test.log ] && mv tests/scaling-pipelines/locust-test.log "${ARTIFACT_DIR}/"
 
 info "Collecting logs..."
 oc -n openshift-pipelines logs --tail=-1 --all-containers=true --max-log-requests=10 -l app.kubernetes.io/name=controller,app.kubernetes.io/part-of=tekton-pipelines,app=tekton-pipelines-controller >"$tekton_pipelines_controller_log" || true

--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -17,6 +17,12 @@ INSTALL_RESULTS="${INSTALL_RESULTS:-false}"
 DEPLOYMENT_TYPE_RESULTS="${DEPLOYMENT_TYPE_RESULTS:-downstream}"
 DEPLOYMENT_RESULTS_UPSTREAM_VERSION="${DEPLOYMENT_RESULTS_UPSTREAM_VERSION:-latest}"
 
+# Locust setup config
+RUN_LOCUST="${RUN_LOCUST:-false}"
+LOCUST_NAMESPACE=locust-operator
+LOCUST_OPERATOR_REPO=locust-k8s-operator
+LOCUST_OPERATOR=locust-operator
+
 DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS="${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-}"
 if [ -n "$DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS" ]; then
     pipelines_controller_ha_buckets=$(( DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS * 2 ))
@@ -388,5 +394,33 @@ EOF
 fi
 
 
+if [ "$RUN_LOCUST" == "true" ]; then
+    # Create namespace if not exists
+    oc get ns "${LOCUST_NAMESPACE}" || oc create ns "${LOCUST_NAMESPACE}"
+
+    # Check if the Helm repo already exists, and add it if it doesn't
+    if ! helm repo list --namespace "${LOCUST_NAMESPACE}" | grep -q "${LOCUST_OPERATOR_REPO}"; then
+        helm repo add "${LOCUST_OPERATOR_REPO}" https://abdelrhmanhamouda.github.io/locust-k8s-operator/ --namespace "${LOCUST_NAMESPACE}"
+    else
+        info "Helm repo \"${LOCUST_OPERATOR_REPO}\" already exists"
+    fi
+
+    # Check if the Helm release already exists, and install it if it doesn't
+    if ! helm list --namespace "${LOCUST_NAMESPACE}" | grep -q "${LOCUST_OPERATOR}"; then
+        helm install "${LOCUST_OPERATOR}" locust-k8s-operator/locust-k8s-operator --namespace "${LOCUST_NAMESPACE}" -f locust-k8s-operator.values.yaml
+    else
+        info "Helm release \"${LOCUST_OPERATOR}\" already exists"
+    fi
+
+    # Wait for all pods in the namespace to be ready
+    kubectl wait --timeout=180s --namespace "${LOCUST_NAMESPACE}" --for=condition=ready $(kubectl get --namespace "${LOCUST_NAMESPACE}" pod -o name)
+
+    info "Locust-Operator deployment finished"
+
+else
+    fatal "Skipping Locust setup"
+fi
+
+
 info "Create namespace 'utils' some scenarios use"
-kubectl create ns utils
+kubectl get ns utils || kubectl create ns utils

--- a/config/cluster_read_config.yaml
+++ b/config/cluster_read_config.yaml
@@ -276,3 +276,35 @@
 {{ monitor_pod('openshift-pipelines', 'tekton-results-watcher', 15) }}
 {{ monitor_pod('tekton-pipelines', 'tekton-results-api', 15) }}
 {{ monitor_pod('tekton-pipelines', 'tekton-results-watcher', 15) }}
+
+
+# Collect data for Locust Test Results
+{%macro results_scenario(name) -%}
+- name: results.{{name}}.locust_requests_avg_response_time
+  monitoring_query: sum(locust_requests_avg_response_time{name="{{name}}"})
+  monitoring_step: 15
+- name: results.{{name}}.locust_requests_avg_content_length
+  monitoring_query: sum(locust_requests_avg_content_length{name="{{name}}"})
+  monitoring_step: 15
+- name: results.{{name}}.locust_requests_current_rps
+  monitoring_query: sum(locust_requests_current_rps{name="{{name}}"})
+  monitoring_step: 15
+- name: results.{{name}}.locust_requests_current_fail_per_sec
+  monitoring_query: sum(locust_requests_current_fail_per_sec{name="{{name}}"})
+  monitoring_step: 15
+- name: results.{{name}}.locust_requests_num_failures
+  monitoring_query: sum(locust_requests_num_failures{name="{{name}}"})
+  monitoring_step: 15
+- name: results.{{name}}.locust_errors
+  monitoring_query: sum(locust_errors{name="{{name}}"})
+  monitoring_step: 15
+{%- endmacro %}
+
+- name: results.locust_requests_fail_ratio
+  monitoring_query: locust_requests_fail_ratio
+  monitoring_step: 15
+- name: results.locust_users
+  monitoring_query: locust_users
+  monitoring_step: 15
+
+{{ results_scenario('Aggregated') }}

--- a/config/locust-k8s-operator.values.yaml
+++ b/config/locust-k8s-operator.values.yaml
@@ -1,0 +1,21 @@
+image:
+  repository: "quay.io/backstage-performance/locust-k8s-operator"
+  tag: "latest"
+  pullPolicy: Always
+
+k8s:
+  clusterRole:
+    enabled: true
+
+config:
+  loadGenerationPods:
+    resource:
+      cpuRequest: 250m
+      memRequest: 128Mi
+      ephemeralRequest: 30Mi
+      cpuLimit: 2000m
+      memLimit: 2Gi
+      ephemeralLimit: 100Mi
+    metricsExporter:
+      image: "quay.io/backstage-performance/locust_exporter:latest"
+      pullPolicy: Always

--- a/tests/scaling-pipelines/scenario/common/lib.sh
+++ b/tests/scaling-pipelines/scenario/common/lib.sh
@@ -299,14 +299,15 @@ function oc_apply_manifest() {
 function run_locust() {
     # Runs Locust API load test on cluster
     if [ "$RUN_LOCUST" == "true" ]; then
-        # SCENARIO is the filename of the locust test inside "locust" directory inside test scenario directory. 
-        # The filename should follow alpha,numeric,hyphens and should NOT contain ".py" extension.
-        local SCENARIO="$1"
-        local LOCUST_HOST="$2"
-        local LOCUST_USERS="$3"
-        local LOCUST_SPAWN_RATE="$4"
-        local LOCUST_DURATION="$5"
-        
+        # SCENARIO is the filename of the locust test in "locust" directory. 
+        # The filename should only follow alpha,numeric,hyphens characters and should NOT contain ".py" extension.
+        export SCENARIO="$1"
+        export LOCUST_HOST="$2"
+        export LOCUST_USERS="$3"
+        export LOCUST_SPAWN_RATE="$4"
+        export LOCUST_DURATION="$5"
+        export LOCUST_WORKERS="$6"
+        export LOCUST_EXTRA_CMD="$7"
 
         # Locust test
         local LOCUST_NAMESPACE=locust-operator
@@ -345,7 +346,7 @@ function run_locust() {
 
         # Get Locust master logs
         echo "Getting locust master log:"
-        kubectl logs --namespace "${LOCUST_NAMESPACE}" -f -l performance-test-pod-name=${SCENARIO}-test-master | tee $LOCUST_LOG
+        kubectl logs --namespace "${LOCUST_NAMESPACE}" -f -l performance-test-pod-name=${SCENARIO}-test-master 2>&1 | tee -a $LOCUST_LOG
 
         # Record test end time
         date --utc -Ins > "${TMP_DIR}/benchmark-after"

--- a/tests/scaling-pipelines/scenario/common/lib.sh
+++ b/tests/scaling-pipelines/scenario/common/lib.sh
@@ -320,6 +320,10 @@ function run_locust() {
 
         info "Running Locust Scenario: ${SCENARIO}"
 
+        # Cleanup locust jobs if it already exists
+        kubectl delete --ignore-not-found=true --namespace "${LOCUST_NAMESPACE}" LocustTest "${SCENARIO}.test"
+        kubectl delete --ignore-not-found=true --namespace "${LOCUST_NAMESPACE}" configmap locust."${SCENARIO}"
+
         # Apply locust test template with environment variable substitution
         cat $LOCUST_TEMPLATE | envsubst | kubectl apply --namespace "${LOCUST_NAMESPACE}" -f -
 
@@ -351,13 +355,6 @@ function run_locust() {
         # Record test end time
         date --utc -Ins > "${TMP_DIR}/benchmark-after"
 
-        # TODO: Collect Prometheus metrics for Locust test 
-
-
-        # Cleanup locust job and configmaps
-        kubectl delete --namespace "${LOCUST_NAMESPACE}" LocustTest "${SCENARIO}.test"
-
-        kubectl delete --namespace "${LOCUST_NAMESPACE}" configmap locust."${SCENARIO}"
     else 
         warning "RUN_LOCUST env variable is not set for Locust testing."
     fi

--- a/tests/scaling-pipelines/scenario/common/locust-test-template.yaml
+++ b/tests/scaling-pipelines/scenario/common/locust-test-template.yaml
@@ -1,0 +1,17 @@
+apiVersion: locust.io/v1
+kind: LocustTest
+metadata:
+  name: ${SCENARIO}.test
+spec:
+  image: quay.io/backstage-performance/locust:latest
+  imagePullPolicy: Always
+  masterCommandSeed: --locustfile /lotest/src/${SCENARIO}.py
+    --host ${LOCUST_HOST}
+    --users ${LOCUST_USERS}
+    --spawn-rate ${LOCUST_SPAWN_RATE}
+    --run-time ${LOCUST_DURATION}
+    ${LOCUST_EXTRA_CMD}
+  workerCommandSeed: --locustfile /lotest/src/${SCENARIO}.py
+    ${LOCUST_EXTRA_CMD}
+  workerReplicas: ${LOCUST_WORKERS}
+  configMap: locust.${SCENARIO}

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/.gitignore
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/.gitignore
@@ -1,1 +1,2 @@
 pipeline.yaml
+concurrency.txt

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/README.md
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/README.md
@@ -1,6 +1,6 @@
 # "timebased-sign-pruner" scenario
 
-This scenario is supposed to stress Pipelines, Chains controller and Pruner by creating PR/TR at constant rate.
+This scenario is supposed to stress Pipelines, Chains controller and Pruner by creating PR/TR at constant rate. The first part of the scenario evaluates the performances of TektonResults capacity to fetch and stores logs into persistent layer. The second part of the scenario, we run two locust API tests named *fetch-log* and *fetch-records* that stress tests the Tekton Results API.
 
 The following environment variables are available for controlling timeouts:
 - **TOTAL_TIMEOUT**: Total time for test execution (Default: 2 hours)
@@ -12,5 +12,11 @@ The following environment variables are available for controlling the PR/TR payl
 - **TEST_BIGBANG_MULTI_STEP__STEP_COUNT**: Total number of steps per Task (Default: 10 steps)
 - **TEST_BIGBANG_MULTI_STEP__LINE_COUNT**: Total number of unique output log lines per step (Default: 15 lines)
 
+The following environment variables are available to set Locust Test parameters:
+- **LOCUST_USERS**: Total number of users to spawn (Default: 100)
+- **LOCUST_SPAWN_RATE**: Number of users to spawn every second (Default: 10)
+- **LOCUST_DURATION**: Total duration for locust testing (Default: 15m)
+- **LOCUST_WORKERS**: Number of Locust worker pods (Default: 5)
+- **LOCUST_EXTRA_CMD**: Additional Locust Command-line parameters.
 
 This scenario **supports** multi-namespace testing through *TEST_NAMESPACE* env variable.

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-log.py
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-log.py
@@ -4,18 +4,25 @@ import urllib3
 
 urllib3.disable_warnings(InsecureRequestWarning)
 
-class FetchResultLogTest(HttpUser): 
+
+class FetchResultLogTest(HttpUser):
+    '''
+    Fetch Log content for specific PipelineRun or TaskRun
+    '''
     def on_start(self):
         self.client.verify = False
 
         # Fetch all records and extract one id
-        records = self.client.get("/apis/results.tekton.dev/v1alpha2/parents/-/results/-/records", name='fetch_id').json()['records']
+        records = self.client.get(
+            "/apis/results.tekton.dev/v1alpha2/parents/-/results/-/records",
+            name='fetch_id').json()['records']
 
         self.log_id = None
+
         # Look for TaskRun/PipelineRun object to fetch logs
         for record in records:
             if "data" in record and 'type' in record['data'] and (
-                record['data']['type'].endswith(".PipelineRun") or 
+                record['data']['type'].endswith(".PipelineRun") or
                 record['data']['type'].endswith(".TaskRun")
             ):
                 self.log_id = record['name']
@@ -29,4 +36,7 @@ class FetchResultLogTest(HttpUser):
     def get_log(self) -> None:
         """Get Log content for a result"""
         if self.log_id:
-            self.client.get(f"/apis/results.tekton.dev/v1alpha2/parents/{self.log_id}", name="/log")
+            self.client.get(
+                f"/apis/results.tekton.dev/v1alpha2/parents/{self.log_id}",
+                name="/log"
+            )

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-log.py
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-log.py
@@ -1,0 +1,32 @@
+from locust import HttpUser, task
+from urllib3.exceptions import InsecureRequestWarning
+import urllib3
+
+urllib3.disable_warnings(InsecureRequestWarning)
+
+class FetchResultLogTest(HttpUser): 
+    def on_start(self):
+        self.client.verify = False
+
+        # Fetch all records and extract one id
+        records = self.client.get("/apis/results.tekton.dev/v1alpha2/parents/-/results/-/records", name='fetch_id').json()['records']
+
+        self.log_id = None
+        # Look for TaskRun/PipelineRun object to fetch logs
+        for record in records:
+            if "data" in record and 'type' in record['data'] and (
+                record['data']['type'].endswith(".PipelineRun") or 
+                record['data']['type'].endswith(".TaskRun")
+            ):
+                self.log_id = record['name']
+                break
+
+        # Replace /records with /logs endpoint to fetch the log data for the PipelineRun or TaskRun
+        if self.log_id:
+            self.log_id = self.log_id.replace("/records", "/logs")
+
+    @task
+    def get_log(self) -> None:
+        """Get Log content for a result"""
+        if self.log_id:
+            self.client.get(f"/apis/results.tekton.dev/v1alpha2/parents/{self.log_id}", name="/log")

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-records.py
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-records.py
@@ -1,0 +1,18 @@
+from locust import HttpUser, task
+from urllib3.exceptions import InsecureRequestWarning
+import urllib3
+
+urllib3.disable_warnings(InsecureRequestWarning)
+
+class FetchRecordsTest(HttpUser):
+    def on_start(self):
+        self.client.verify = False
+
+        # Extract UID and Path for a Result
+        response = self.client.get("/apis/results.tekton.dev/v1alpha2/parents/-/results", name='fetch_id').json()['records']
+        self.result_id = response[0]['name']
+
+    @task
+    def get_records(self) -> None:
+        """Get Records for a particular result"""
+        self.client.get(f"/apis/results.tekton.dev/v1alpha2/parents/{self.result_id}/records", name="/records")

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-records.py
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-records.py
@@ -4,15 +4,24 @@ import urllib3
 
 urllib3.disable_warnings(InsecureRequestWarning)
 
+
 class FetchRecordsTest(HttpUser):
+    '''
+    User scenario fetches a specific record
+    '''
     def on_start(self):
         self.client.verify = False
 
-        # Extract UID and Path for a Result
-        response = self.client.get("/apis/results.tekton.dev/v1alpha2/parents/-/results", name='fetch_id').json()['records']
-        self.result_id = response[0]['name']
+        # Extract UID and Path for a Record
+        response = self.client.get(
+            "/apis/results.tekton.dev/v1alpha2/parents/-/results/-/records",
+            name='fetch_id').json()['records']
+        self.record_id = response[0]['name']
 
     @task
     def get_records(self) -> None:
         """Get Records for a particular result"""
-        self.client.get(f"/apis/results.tekton.dev/v1alpha2/parents/{self.result_id}/records", name="/records")
+        self.client.get(
+            f"/apis/results.tekton.dev/v1alpha2/parents/{self.record_id}",
+            name="/records"
+        )

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/setup.sh
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/setup.sh
@@ -13,11 +13,22 @@ TOTAL_TIMEOUT=${TOTAL_TIMEOUT:-7200}
 CHAINS_WAIT_TIME=${CHAINS_WAIT_TIME:-600} # [Default: 10 mins]
 PRUNER_WAIT_TIME=${PRUNER_WAIT_TIME:-600} # [Default: 10 mins]
 
+# Locust test configurations
+LOCUST_HOST="https://tekton-results-api-service.openshift-pipelines.svc.cluster.local:8080"
+LOCUST_USERS=${LOCUST_USERS:-100}
+LOCUST_SPAWN_RATE=${LOCUST_SPAWN_RATE:-10}
+LOCUST_DURATION="$((TOTAL_TIMEOUT * 1 / 8))s" # Run the test for 1/8th duration of the overall test 
+LOCUST_WORKERS=${LOCUST_WORKERS:-5}
+LOCUST_EXTRA_CMD="${LOCUST_EXTRA_CMD:-}"
+
 chains_setup_tekton_tekton_
 
 chains_stop
 
 pruner_stop
+
+# We will use varying concurrency to set the concurreny to zero before starting locust test
+echo $TEST_CONCURRENT > scenario/$TEST_SCENARIO/concurrency.txt
 
 #  Timeout before enabling Chains 
 (
@@ -30,6 +41,23 @@ pruner_stop
 (
     wait_for_timeout $PRUNER_WAIT_TIME "enable Pruner"
     pruner_start
+) &
+
+# Timeout before setting concurrency to zero
+(
+    wait_for_timeout $((TOTAL_TIMEOUT * 3 / 4)) "reducing concurrency to 0"
+    echo 0 > scenario/$TEST_SCENARIO/concurrency.txt
+) &
+
+# Timeout before starting Locust test
+(
+    wait_for_timeout $((TOTAL_TIMEOUT * 3 / 4)) "starting Locust Test"
+
+    # Run fetch-log loadtest scenario
+    run_locust "fetch-log" $LOCUST_HOST $LOCUST_USERS $LOCUST_SPAWN_RATE $LOCUST_DURATION $LOCUST_WORKERS "$LOCUST_EXTRA_CMD"
+
+    # Run fetch-records loadtest scenario
+    run_locust "fetch-records" $LOCUST_HOST $LOCUST_USERS $LOCUST_SPAWN_RATE $LOCUST_DURATION $LOCUST_WORKERS "$LOCUST_EXTRA_CMD"
 ) &
 
 # Stop the execution after total timeout duration

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/tierdown.sh
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/tierdown.sh
@@ -1,3 +1,18 @@
 source scenario/common/lib.sh
 
+# Locust test configurations
+LOCUST_HOST="https://tekton-results-api-service.openshift-pipelines.svc.cluster.local:8080"
+LOCUST_USERS=${LOCUST_USERS:-100}
+LOCUST_SPAWN_RATE=${LOCUST_SPAWN_RATE:-10}
+LOCUST_DURATION="${LOCUST_DURATION:-15m}"
+LOCUST_WORKERS=${LOCUST_WORKERS:-5}
+LOCUST_EXTRA_CMD="${LOCUST_EXTRA_CMD:-}"
+
+# Run fetch-log loadtest scenario
+run_locust "fetch-log" $LOCUST_HOST $LOCUST_USERS $LOCUST_SPAWN_RATE $LOCUST_DURATION $LOCUST_WORKERS "$LOCUST_EXTRA_CMD"
+
+# Run fetch-records loadtest scenario
+run_locust "fetch-records" $LOCUST_HOST $LOCUST_USERS $LOCUST_SPAWN_RATE $LOCUST_DURATION $LOCUST_WORKERS "$LOCUST_EXTRA_CMD"
+
+# Update test end time
 set_ended_now

--- a/tools/runs-to-csv.sh
+++ b/tools/runs-to-csv.sh
@@ -80,7 +80,18 @@ find . -name benchmark-tekton.json -print0 | while IFS= read -r -d '' filename; 
         .measurements.apiserver.cpu.mean,
         .measurements.apiserver.memory.mean,
         .measurements."kube-apiserver".cpu.mean,
-        .measurements."kube-apiserver".memory.mean
+        .measurements."kube-apiserver".memory.mean,
+        .results.Aggregated.locust_requests_current_rps.mean,
+        .results.Aggregated.locust_requests_current_rps.max,
+        .results.Aggregated.locust_requests_num_failures.max,
+        .results.locust_requests_fail_ratio.mean,
+        .results.Aggregated.locust_requests_avg_response_time.min,
+        .results.Aggregated.locust_requests_avg_response_time.mean,
+        .results.Aggregated.locust_requests_avg_response_time.percentile90,
+        .results.Aggregated.locust_requests_avg_response_time.percentile99,
+        .results.Aggregated.locust_requests_avg_response_time.percentile999,
+        .results.Aggregated.locust_requests_avg_response_time.max,
+        .results.Aggregated.locust_requests_avg_content_length.max
         ] | @csv' \
         && rc=0 || rc=1
     if [[ "$rc" -ne 0 ]]; then


### PR DESCRIPTION
This PR adds support to run Locust API tests as part of Performance benchmarking. 

# Issue Link
https://issues.redhat.com/browse/SRVKP-6575

# Changes

- Installing Locust-Operator on Cluster during the Cluster Setup by setting `RUN_LOCUST=true`. This will install all the necessary operators and in-addition will enable service monitor to forward for locust metrics from locust test jobs into prometheus.
- Capture aggregated values of request latency for the test in output json files and raw monitoring collection.
- Updates test scenario `timebased-sign-pruner` to add locust test jobs (more info below).

## timebased-sign-pruner (Locust Changes)

The first part of the scenario evaluates the performances of TektonResults, Pipeline Controllers, Chains and Pruner by creating PR/TR workloads. In the second part of the scenario, we trigger locust API tests named *fetch-log* and *fetch-records* to stress test the Tekton Results API.

The following environment variables are available to set Locust Test parameters:
- **LOCUST_USERS**: Total number of users to spawn (Default: 100)
- **LOCUST_SPAWN_RATE**: Number of users to spawn every second (Default: 10)
- **LOCUST_DURATION**: Total duration for locust testing (Default: 15m)
- **LOCUST_WORKERS**: Number of Locust worker pods (Default: 5)
- **LOCUST_EXTRA_CMD**: Additional Locust Command-line parameters.

# How to run?

Run the following in OpenShift cluster:

```
# Setup
export DEPLOYMENT_TYPE="downstream"
export DEPLOYMENT_VERSION="1.15"
export DEPLOYMENT_PIPELINES_CONTROLLER_RESOURCES="1/2Gi/1/2Gi"
export INSTALL_RESULTS="true"
export RUN_LOCUST="true"

ci-scripts/setup-cluster.sh

# Run Test
export TEST_DO_CLEANUP="false"
export TEST_NAMESPACE="2"
export TEST_CONCURRENT="3"
export TEST_SCENARIO="timebased-sign-pruner"
export TEST_BIGBANG_MULTI_STEP__TASK_COUNT="1"
export TEST_BIGBANG_MULTI_STEP__STEP_COUNT="1"
export TEST_BIGBANG_MULTI_STEP__LINE_COUNT="1"
export CHAINS_WAIT_TIME="0"
export PRUNER_WAIT_TIME="0"

# Run the PR/TR generation for 3 minutes
export TOTAL_TIMEOUT="180" 

export LOCUST_DURATION="1m"
export LOCUST_USERS=100
export LOCUST_SPAWN_RATE=10
export LOCUST_WORKERS=5

ci-scripts/load-test.sh

# Capture Result
ci-scripts/collect-results.sh
```

Tested the above changes on v1.15 release in ClusterBot OpenShift instance.
