### PR TITLE
fix(SRVKP-6791): Issue with DB dump in non-interactive kubectl exec mode

### DIFF
--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -105,7 +105,7 @@ if [ "$INSTALL_RESULTS" == "true" ]; then
     pg_pwd=$(oc -n openshift-pipelines get secret tekton-results-postgres -o json | jq -r '.data.POSTGRES_PASSWORD' | base64 -d)
 
     # Dump Postgres Database into SQL file
-    oc -n openshift-pipelines exec -it tekton-results-postgres-0 -- bash -c "PGPASSWORD=$pg_pwd pg_dump tekton-results -U $pg_user" > $results_api_db_sql
+    oc -n openshift-pipelines exec -i tekton-results-postgres-0 -- bash -c "PGPASSWORD=$pg_pwd pg_dump tekton-results -U $pg_user" > $results_api_db_sql
 
 
     info "Collecting Results-API log data"


### PR DESCRIPTION
#### Background
When using `-t` flag with `kubectl exe` in CI environment, the job fails to connect into the container in interactive mode and fails the CI run.

#### Resolution
Removes `--tty` flag and uses only the `-i` flag to pass the command line arguments for taking pg_dump from postgres DB.