### PR TITLE
fix(SRVKP-6801): CI issue due to user-workload monitoring failure

### DIFF
--- a/ci-scripts/lib.sh
+++ b/ci-scripts/lib.sh
@@ -23,6 +23,14 @@ function fatal() {
     exit 1
 }
 
+function describe_entity(){
+    local ns="$1"
+    local entity="$2"
+    local l="$3"
+    
+    kubectl -n "$ns" describe "$entity" -l "$l"
+}
+
 function entity_by_selector_exists() {
     local ns
     local entity
@@ -72,6 +80,7 @@ function wait_for_entity_by_selector() {
     while ! entity_by_selector_exists "$ns" "$entity" "$l" "$expected"; do
         now=$(date --utc +%s)
         if [[ $(( now - before )) -ge "$timeout" ]]; then
+            describe_entity "$ns" "$entity" "$l"
             fatal "Required $entity did not appeared before timeout"
         fi
         debug "Still not ready ($(( now - before ))/$timeout), waiting and trying again"

--- a/ci-scripts/lib.sh
+++ b/ci-scripts/lib.sh
@@ -23,14 +23,6 @@ function fatal() {
     exit 1
 }
 
-function describe_entity(){
-    local ns="$1"
-    local entity="$2"
-    local l="$3"
-    
-    kubectl -n "$ns" describe "$entity" -l "$l"
-}
-
 function entity_by_selector_exists() {
     local ns
     local entity
@@ -80,7 +72,6 @@ function wait_for_entity_by_selector() {
     while ! entity_by_selector_exists "$ns" "$entity" "$l" "$expected"; do
         now=$(date --utc +%s)
         if [[ $(( now - before )) -ge "$timeout" ]]; then
-            describe_entity "$ns" "$entity" "$l"
             fatal "Required $entity did not appeared before timeout"
         fi
         debug "Still not ready ($(( now - before ))/$timeout), waiting and trying again"

--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -616,12 +616,12 @@ if [ "$RUN_LOCUST" == "true" ]; then
     wait_for_entity_by_selector 180 "${LOCUST_NAMESPACE}" pod app.kubernetes.io/name=locust-k8s-operator
 
     info "Enabling user workload monitoring"
-    config_file=$(mktemp)
+    config_dir=$(mktemp -d)
     if oc -n openshift-monitoring get cm cluster-monitoring-config; then
-        oc -n openshift-monitoring extract configmap/cluster-monitoring-config --to=. --keys=$config_file
-        sed -i '/^enableUserWorkload:/d' $config_file
-        echo -e "\nenableUserWorkload: true" >> $config_file
-        oc -n openshift-monitoring set data configmap/cluster-monitoring-config --from-file=$config_file
+        oc -n openshift-monitoring extract configmap/cluster-monitoring-config --to=$config_dir --keys=config.yaml
+        sed -i '/^enableUserWorkload:/d' $config_dir/config.yaml
+        echo -e "\nenableUserWorkload: true" >> $config_dir/config.yaml
+        oc -n openshift-monitoring set data configmap/cluster-monitoring-config --from-file=$config_dir/config.yaml
     else
         cat <<EOF | kubectl apply -f -
 apiVersion: v1

--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -635,7 +635,7 @@ data:
 EOF
   fi
 
-    wait_for_entity_by_selector 300 "openshift-user-workload-monitoring" StatefulSet operator.prometheus.io/name=user-workload
+    wait_for_entity_by_selector 600 "openshift-user-workload-monitoring" StatefulSet operator.prometheus.io/name=user-workload
     kubectl -n openshift-user-workload-monitoring rollout status --watch --timeout=600s StatefulSet/prometheus-user-workload
     kubectl -n openshift-user-workload-monitoring wait --for=condition=ready pod -l app.kubernetes.io/component=prometheus
     kubectl -n openshift-user-workload-monitoring get pod


### PR DESCRIPTION
# Description

The configmap updates for `cluster-monitoring-config` was done on a tempfile where the `enableUserWorkload: true` flag was added, if its missing. The issue occured when we tried to map the temp file back to the configmap using its original temp directory location (/tmp.xyz). This created a separate `temp.xyz` key in the conifgmap instead of `config.yaml`. With this PR, we refer to the temp directory and create a `config.yaml` within this directory to do the in-place modifications.
