### PR TITLE
feat(SRVKP-6872,SRVKP-6869,SRVKP-6875): Improve ResultsAPI DB collect metrics

### DIFF
--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -16,7 +16,8 @@ creationtimestamp_collection_log=$ARTIFACT_DIR/creationtimestamp-collection.log
 results_api_logs="$ARTIFACT_DIR/results-api-logs.txt"
 results_api_json="$ARTIFACT_DIR/results-api-logs.json"
 results_api_error_logs="$ARTIFACT_DIR/results-api-logs-parse-errors.txt"
-results_api_db_sql="$ARTIFACT_DIR/tekton-results-postgres-pgdump.sql"
+results_api_db_sql="$ARTIFACT_DIR/tekton-results-postgres-pgdump.dump"
+results_api_db_query_stat="$ARTIFACT_DIR/tekton-results-postgres-query.json"
 INSTALL_RESULTS="${INSTALL_RESULTS:-false}"
 
 info "Collecting artifacts..."
@@ -104,8 +105,23 @@ if [ "$INSTALL_RESULTS" == "true" ]; then
     pg_user=$(oc -n openshift-pipelines get secret tekton-results-postgres -o json | jq -r '.data.POSTGRES_USER' | base64 -d)
     pg_pwd=$(oc -n openshift-pipelines get secret tekton-results-postgres -o json | jq -r '.data.POSTGRES_PASSWORD' | base64 -d)
 
-    # Dump Postgres Database into SQL file
-    oc -n openshift-pipelines exec -i tekton-results-postgres-0 -- bash -c "PGPASSWORD=$pg_pwd pg_dump tekton-results -U $pg_user" > $results_api_db_sql
+    # Dump Postgres Database
+    oc -n openshift-pipelines exec -i tekton-results-postgres-0 -- bash -c "PGPASSWORD=$pg_pwd pg_dump --format=c tekton-results -U $pg_user --file=/tmp/pg_data.dump"
+
+    kubectl -n openshift-pipelines cp --retries 10 tekton-results-postgres-0:/tmp/pg_data.dump $results_api_db_sql
+    
+    # Capture DB Table counts
+    info "Collecting Results-API DB Table Counts"
+
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select type, count(*) from records group by type" "$results_api_db_query_stat"
+
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select recordsummary_type , count(*) from results group by recordsummary_type" "$results_api_db_query_stat"
+
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select * from results where recordsummary_type = ''" "$results_api_db_query_stat"
+
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select parent, count(*) from records group by parent order by parent" "$results_api_db_query_stat"
+
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select parent, type, count(*) from records group by parent, type order by parent" "$results_api_db_query_stat"
 
 
     info "Collecting Results-API log data"

--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -17,7 +17,6 @@ results_api_logs="$ARTIFACT_DIR/results-api-logs.txt"
 results_api_json="$ARTIFACT_DIR/results-api-logs.json"
 results_api_error_logs="$ARTIFACT_DIR/results-api-logs-parse-errors.txt"
 results_api_db_sql="$ARTIFACT_DIR/tekton-results-postgres-pgdump.dump"
-results_api_db_query_stat="$ARTIFACT_DIR/tekton-results-postgres-query.json"
 INSTALL_RESULTS="${INSTALL_RESULTS:-false}"
 
 info "Collecting artifacts..."
@@ -113,15 +112,15 @@ if [ "$INSTALL_RESULTS" == "true" ]; then
     # Capture DB Table counts
     info "Collecting Results-API DB Table Counts"
 
-    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select type, count(*) from records group by type" "$results_api_db_query_stat"
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select type, count(*) from records group by type" "$monitoring_collection_data"
 
-    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select recordsummary_type , count(*) from results group by recordsummary_type" "$results_api_db_query_stat"
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select recordsummary_type , count(*) from results group by recordsummary_type" "$monitoring_collection_data"
 
-    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select * from results where recordsummary_type = ''" "$results_api_db_query_stat"
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select * from results where recordsummary_type = ''" "$monitoring_collection_data"
 
-    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select parent, count(*) from records group by parent order by parent" "$results_api_db_query_stat"
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select parent, count(*) from records group by parent order by parent" "$monitoring_collection_data"
 
-    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select parent, type, count(*) from records group by parent, type order by parent" "$results_api_db_query_stat"
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select parent, type, count(*) from records group by parent, type order by parent" "$monitoring_collection_data"
 
 
     info "Collecting Results-API log data"

--- a/ci-scripts/lib.sh
+++ b/ci-scripts/lib.sh
@@ -103,9 +103,9 @@ function capture_results_db_query(){
     # Check if the output file exists
     if [ -f "$output_file" ]; then
         # Append to existing JSON array in the file
-        jq --argjson new_entry "$new_entry" '. += [$new_entry]' "$output_file" > "${output_file}.tmp" && mv "${output_file}.tmp" "$output_file"
+        jq --argjson new_entry "$new_entry" '.results.ResultsDB.queries += [$new_entry]' "$output_file" > "${output_file}.tmp" && mv "${output_file}.tmp" "$output_file"
     else
         # Create a new JSON array and add the new entry
-        echo "[$new_entry]" > "$output_file"
+        echo "{}" | jq ".results.ResultsDB.queries = [$new_entry]" > "$output_file"
     fi
 }

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-record.py
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-record.py
@@ -13,10 +13,21 @@ class FetchRecordsTest(HttpUser):
         self.client.verify = False
 
         # Extract UID and Path for a Record
-        response = self.client.get(
+        records = self.client.get(
             "/apis/results.tekton.dev/v1alpha2/parents/-/results/-/records",
             name='fetch_id').json()['records']
-        self.record_id = response[0]['name']
+
+        self.record_id = None
+
+        # Look for TaskRun objects
+        # In v1.15 there exists additional category type - results.tekton.dev/v1alpha2.Log
+        # We are mainly interested to compare API performance for /record endpoint of specific type
+        for record in records:
+            if "data" in record and 'type' in record['data'] and (
+                record['data']['type'].endswith(".TaskRun")
+            ):
+                self.record_id = record['name']
+                break
 
     @task
     def get_record(self) -> None:


### PR DESCRIPTION
# Changes
## [SRVKP-6872](https://issues.redhat.com//browse/SRVKP-6872): Improve DB data capture for collecting metadata
- Switched to custom format to take Postgres dump by using `--format=c` flag. Now the data is stored in compressed binary format and can be restored using `pg_restore` command.
- Add new methods that captures SQL results for Result and Record tables from Postgres. Result from Queries are stored in `benchmark-tekton.json` under `.ResultsDB.queries`.

## [SRVKP-6869](https://issues.redhat.com//browse/SRVKP-6869): Make API test to work with random records
- For the `/log` locust test scenario now we add a random shuffle in picking record entry from the list.

## [SRVKP-6875](https://issues.redhat.com//browse/SRVKP-6875): Add a check in Locust log scenario to improve error handling
- Adds a validation check after `/log` locust testing to pass the scenario only if we have a 200 status code response with non-zero length payload size.
- To avoid mixing results from PipelineRun and TaskRun logs, now the record ID is only considered for a TaskRun object. Locust test for `/record` endpoint also follows the same lookup to only search for TaskRun object.
