### PR TITLE
feat(SRVKP-6576): update pod_suffix_regex in cluster_ready_library

### DIFF
--- a/config/cluster_read_library.yaml
+++ b/config/cluster_read_library.yaml
@@ -1,4 +1,4 @@
-{% macro monitor_pod(namespace, pod, step=15, pod_suffix_regex='-[0-9a-f]+-.*') -%}
+{% macro monitor_pod(namespace, pod, step=15, pod_suffix_regex='.*') -%}
 # Gather monitoring data about the pod
 - name: measurements.{{ pod }}.cpu
   monitoring_query: sum(pod:container_cpu_usage:sum{namespace='{{ namespace }}', pod=~'{{ pod }}{{ pod_suffix_regex }}'})


### PR DESCRIPTION
Updates `pod_suffix_regex` to match names based on prefix match for both Deployment and StatefulSet pod names.