### PR TITLE
feat(SRVKP-6187): Loki & log Collector Metrics

### DIFF
--- a/config/cluster_read_config.yaml
+++ b/config/cluster_read_config.yaml
@@ -289,3 +289,15 @@
 - name: measurements.logs.loki.ingester_records_logged_rate
   monitoring_query: sum(rate(loki_ingester_wal_records_logged_total[5m]))
   monitoring_step: 15
+- name: measurements.logs.loki.internal_error_log_count
+  monitoring_query: sum(loki_internal_log_messages_total{level='error'})
+  monitoring_step: 15
+- name: measurements.logs.loki.internal_debug_log_count
+  monitoring_query: sum(loki_internal_log_messages_total{level='debug'})
+  monitoring_step: 15
+- name: measurements.logs.loki.internal_info_log_count
+  monitoring_query: sum(loki_internal_log_messages_total{level='info'})
+  monitoring_step: 15
+- name: measurements.logs.loki.internal_warn_log_count
+  monitoring_query: sum(loki_internal_log_messages_total{level='warn'})
+  monitoring_step: 15

--- a/config/cluster_read_config.yaml
+++ b/config/cluster_read_config.yaml
@@ -249,3 +249,43 @@
 {{ cluster_read_library.results_scenario('/log') }}
 {{ cluster_read_library.results_scenario('/record') }}
 {{ cluster_read_library.results_scenario('/records') }}
+
+
+# Collect metrics related to logging
+## Rate metrics
+- name: measurements.logs.collection_rate # Bytes per second (Bps)
+  monitoring_query: sum(rate(vector_component_received_bytes_total{component_kind="source", component_type!="internal_metrics"}[5m]))
+  monitoring_step: 15
+- name: measurements.logs.sent_rate # Bytes per second (Bps)
+  monitoring_query: sum(rate(vector_component_sent_bytes_total{component_kind="sink", component_type!="prometheus_exporter"}[5m]))
+  monitoring_step: 15
+
+## Resource Usage
+- name: measurements.logs.collector.cpu # No. of CPU cores
+  monitoring_query: sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{container='collector'})
+  monitoring_step: 15
+- name: measurements.logs.collector.memory # Bytes
+  monitoring_query: sum(node_namespace_pod_container:container_memory_rss{container="collector"})
+  monitoring_step: 15
+
+## File System Usage
+- name: measurements.logs.open_files
+  monitoring_query: sum(vector_open_files{component_kind="source", component_type="kubernetes_logs"})
+  monitoring_step: 15
+
+## Loki metrics
+- name: measurements.logs.loki.events_sent
+  monitoring_query: sum(vector_component_sent_events_total{component_kind='sink', component_type='loki'})
+  monitoring_step: 15
+- name: measurements.logs.loki.event_bytes_sent # Bytes
+  monitoring_query: sum(vector_component_sent_event_bytes_total{component_kind='sink', component_type='loki'}) 
+  monitoring_step: 15
+- name: measurements.logs.loki.distributor_lines_received
+  monitoring_query: sum(loki_distributor_lines_received_total)
+  monitoring_step: 15
+- name: measurements.logs.loki.distributor_ingester_appends
+  monitoring_query: sum(loki_distributor_ingester_appends_total)
+  monitoring_step: 15
+- name: measurements.logs.loki.ingester_records_logged_rate
+  monitoring_query: sum(rate(loki_ingester_wal_records_logged_total[5m]))
+  monitoring_step: 15


### PR DESCRIPTION
This PR adds new Loki & Log collector metrics in `cluster_read_config.yaml`.

- `logs.collection_rate`: Rate (Bytes per second)at which logs read by collector
![image](https://github.com/user-attachments/assets/59ec827b-c90e-422c-9af8-c9937ce736fb)


- `logs.sent_rate`: Rate (Bytes per second)at which logs sent by collector
![image](https://github.com/user-attachments/assets/35209dc7-b18d-4c96-a82d-2c761bc61c6f)


- `logs.collector.cpu`: CPU usage for collector pods.
![image](https://github.com/user-attachments/assets/a50bc502-27b8-4372-ae72-cca185ca5b99)


- `logs.collector.memory`: Memory usage for collector pods.
![image](https://github.com/user-attachments/assets/6aa7fd4c-f78c-456c-b360-7d6461ade169)


- `logs.collector.open_files`: No. of files open files.
![image](https://github.com/user-attachments/assets/35d1619d-2f10-4454-af20-29f0c6a4cf2e)


- `logs.loki.events_sent`: Total number of events emitted to Loki
![image](https://github.com/user-attachments/assets/4446272d-9503-4d24-a362-95e4c0ac88e4)


- `logs.loki.event_bytes_sent`: Total number of bytes emitted to Loki
![image](https://github.com/user-attachments/assets/853a7371-e3a3-464c-a7c1-c9f591afcca9)


- `logs.loki.distributor_lines_received`: Total number of lines received by Loki Distributor
![image](https://github.com/user-attachments/assets/3ab43bf3-145d-42ab-b199-d994b305d1f6)


- `logs.loki.distributor_ingester_appends`: Total number of appends to Ingester.
![image](https://github.com/user-attachments/assets/6592d634-45f5-486c-811b-cdf96e977de2)


- `logs.loki.ingester_records_logged_rate`: Rate at which ingester updates WAL.
![image](https://github.com/user-attachments/assets/4658b666-d213-4238-ae08-9feb7669fdf5)

- `logs.loki.internal_error_log_count`: No. of logs messages with level=error reported by loki stack internally.
![image](https://github.com/user-attachments/assets/47eb63b7-f34b-4085-8dea-cb45b24e7307)

- `logs.loki.internal_debug_log_count`: No. of logs messages with level=debug reported by loki stack internally.
![image](https://github.com/user-attachments/assets/0e044cbf-32b0-46bd-b5e6-edc60a35224d)

- `logs.loki.internal_info_log_count`: No. of logs messages with level=info reported by loki stack internally.
![image](https://github.com/user-attachments/assets/a87061a0-97de-48ca-a1d2-43b862c3fea2)

- `logs.loki.internal_warn_log_count`: No. of logs messages with level=warn reported by loki stack internally.
![image](https://github.com/user-attachments/assets/5b6b6e8a-2911-49e8-8feb-53a85c65775b)



The above graphs were captured from a test run with the following configs:

```
export PRUNER_WAIT_TIME="0"
export TEST_SCENARIO="timebased-sign-pruner"       
export CHAINS_WAIT_TIME="0"
export LOCUST_DURATION="2m"
export LOCUST_SPAWN_RATE="1"
export LOCUST_USERS="30"
export LOCUST_WORKERS="2"
export TEST_BIGBANG_MULTI_STEP__LINE_COUNT="2"
export TEST_BIGBANG_MULTI_STEP__STEP_COUNT="1"
export TEST_BIGBANG_MULTI_STEP__TASK_COUNT="1"
export TEST_CONCURRENT="10"
export TEST_NAMESPACE="1"
export TOTAL_TIMEOUT="300"
```
