### PR TITLE
feat(SRVKP-7423): Locust wait time and Records sorting in Log Test

### DIFF
--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-log.py
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/locust/fetch-log.py
@@ -1,5 +1,6 @@
 import urllib3
 from random import shuffle
+from datetime import datetime
 from urllib3.exceptions import InsecureRequestWarning
 from locust import HttpUser, task
 
@@ -19,19 +20,29 @@ class FetchResultLogTest(HttpUser):
             name='fetch_id').json()['records']
 
         # Small Randomness in picking first taskrun for fetching log
-        shuffle(records)
+        # shuffle(records)
 
-        self.log_id = None
+        # Filter for only TR records
+        taskruns = []
+        for record in records:
+            if "data" in record and 'type' in record['data'] and (record['data']['type'].endswith(".TaskRun")):
+                taskruns.append(record)
+
+        # Sort the TRs by date
+        taskruns = sorted(taskruns, key=lambda tr: datetime.fromisoformat(tr["createTime"].replace("Z", "")))
+
+        # Pick the oldest TR reocrd
+        self.log_id = taskruns[0]['name']
 
         # Look for TaskRun object to fetch logs
-        for record in records:
-            if "data" in record and 'type' in record['data'] and (
-                record['data']['type'].endswith(".TaskRun")
-                # Uncomment below to include PipelineRun for search
-                # or record['data']['type'].endswith(".PipelineRun")
-            ):
-                self.log_id = record['name']
-                break
+        # for record in taskruns:
+        #     if "data" in record and 'type' in record['data'] and (
+        #         record['data']['type'].endswith(".TaskRun")
+        #         # Uncomment below to include PipelineRun for search
+        #         # or record['data']['type'].endswith(".PipelineRun")
+        #     ):
+        #         self.log_id = record['name']
+        #         break
 
         # Replace /records with /logs endpoint to fetch the log data for the TaskRun
         if self.log_id:

--- a/tests/scaling-pipelines/scenario/timebased-sign-pruner/tierdown.sh
+++ b/tests/scaling-pipelines/scenario/timebased-sign-pruner/tierdown.sh
@@ -7,6 +7,11 @@ LOCUST_SPAWN_RATE=${LOCUST_SPAWN_RATE:-10}
 LOCUST_DURATION="${LOCUST_DURATION:-15m}"
 LOCUST_WORKERS=${LOCUST_WORKERS:-5}
 LOCUST_EXTRA_CMD="${LOCUST_EXTRA_CMD:-}"
+LOCUST_WAIT_TIME=${LOCUST_WAIT_TIME:-600} # [Default: 10 mins]
+
+# Wait before starting locust test
+# This is implemented to give enough time for openshift-logging to do log sync ups
+wait_for_timeout $LOCUST_WAIT_TIME "start Locust test"
 
 # Run fetch-log loadtest scenario
 run_locust "fetch-log" $LOCUST_HOST $LOCUST_USERS $LOCUST_SPAWN_RATE $LOCUST_DURATION $LOCUST_WORKERS "$LOCUST_EXTRA_CMD"


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/SRVKP-7423

- Introduce new variable `LOCUST_WAIT_TIME` in timebased scenario test to control the wait time before starting locust test. (Default LOCUST_WAIT_TIME=600s) 
- `fetch-log.py` now selects the oldest taskrun record before making /log request. 