### PR TITLE
feat(SRVKP-7449): Installing Tkn Results from Operator (1.18 onwards)

### DIFF
--- a/ci-scripts/lib.sh
+++ b/ci-scripts/lib.sh
@@ -113,5 +113,8 @@ function capture_results_db_query(){
 version_gte() {
     # Compare whether the version number specified in the first argument
     # is greater than or equal to the version number in the second argument.
+
+    # TODO: Use package manager utility for version comparison
+    # https://github.com/openshift-pipelines/performance/pull/64#discussion_r2041881415
     printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
 }

--- a/ci-scripts/lib.sh
+++ b/ci-scripts/lib.sh
@@ -109,3 +109,9 @@ function capture_results_db_query(){
         echo "{}" | jq ".results.ResultsDB.queries = [$new_entry]" > "$output_file"
     fi
 }
+
+version_gte() {
+    # Compare whether the version number specified in the first argument
+    # is greater than or equal to the version number in the second argument.
+    printf '%s\n%s\n' "$2" "$1" | sort --check=quiet --version-sort
+}

--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -549,13 +549,13 @@ spec:
 EOF
 
       if version_gte "$DEPLOYMENT_VERSION" "1.18"; then
-        # Starting 1.18, Results is installed as part of Operator
-        # https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/1.18/html/release_notes/op-release-notes#tekton-results-new-features-1-18_op-release-notes
-        info "Enabling Tekton-Result in Tekton Operator"
-        kubectl patch TektonConfig/config --type merge --patch '{"spec":{"result":{"disabled":false,"auth_disable":true,"targetNamespace":"openshift-pipelines","loki_stack_name":"logging-loki","loki_stack_namespace":"openshift-logging"}}}'
+          # Starting 1.18, Results is installed as part of Operator
+          # https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/1.18/html/release_notes/op-release-notes#tekton-results-new-features-1-18_op-release-notes
+          info "Enabling Tekton-Result in Tekton Operator"
+          kubectl patch TektonConfig/config --type merge --patch '{"spec":{"result":{"disabled":false,"auth_disable":true,"targetNamespace":"openshift-pipelines","loki_stack_name":"logging-loki","loki_stack_namespace":"openshift-logging"}}}'
       else
-        info "Installing Tekton-Result Operator"
-        cat <<EOF | oc apply -n $TEKTON_RESULTS_NS -f -
+          info "Installing Tekton-Result Operator"
+          cat <<EOF | oc apply -n $TEKTON_RESULTS_NS -f -
 apiVersion: operator.tekton.dev/v1alpha1
 kind: TektonResult
 metadata:


### PR DESCRIPTION
This PR adds support to install Tekton Results from operator from 1.18 deployment version. Older version still use the default TektonResults CRD for setup.

https://issues.redhat.com/browse/SRVKP-7449
