### PR TITLE
fix(SRVKP-7449): Disable results for Pipelines v1.18+

### DIFF
--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -133,7 +133,7 @@ if [ "$INSTALL_RESULTS" == "true" ]; then
 
     capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select recordsummary_type , count(*) from results group by recordsummary_type" "$monitoring_collection_data"
 
-    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select * from results where recordsummary_type = ''" "$monitoring_collection_data"
+    capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select count(*) from results where recordsummary_type = ''" "$monitoring_collection_data"
 
     capture_results_db_query "$pg_user" "$pg_pwd" "tekton-results" "select parent, count(*) from records group by parent order by parent" "$monitoring_collection_data"
 

--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -101,7 +101,13 @@ EOF
           kubectl patch TektonConfig/config --type merge --patch '{"spec":{"pipeline":{"performance":{"statefulset-ordinals":true,"buckets":1,"replicas":1}}}}'
         fi
 
-        kubectl patch TektonConfig/config --type merge --patch '{"spec":{"result":{"disabled":true},"pipeline":{"options":{"'$DEPLOYMENT_PIPELINES_CONTROLLER_TYPE'":{"tekton-pipelines-controller":{"spec":{"template":{"spec":{"containers":[{"name":"tekton-pipelines-controller","resources":'"$resources_json"'}]}}}}}}}}}'
+        kubectl patch TektonConfig/config --type merge --patch '{"spec":{"pipeline":{"options":{"'$DEPLOYMENT_PIPELINES_CONTROLLER_TYPE'":{"tekton-pipelines-controller":{"spec":{"template":{"spec":{"containers":[{"name":"tekton-pipelines-controller","resources":'"$resources_json"'}]}}}}}}}}}'
+
+        # Disable Results as its enabled by default in 1.18+ release
+        if version_gte "$DEPLOYMENT_VERSION" "1.18"; then
+            info "Disabling Tekton Results"
+            kubectl patch TektonConfig/config --type merge --patch '{"spec":{"result":{"disabled":true}}}'
+        fi
 
         info "Configure Pipelines HA: ${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-no}"
         if [ -n "$DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS" ]; then


### PR DESCRIPTION
- Reworked on the Tekton Results disable logic to only apply it for v1.18 or above, since in the previous version the setting is not available in operator.
- Update SQL query for fetching empty record type.