### PR TITLE
Add upstream Pipelines controller commit tracking and expand test coverage

### DIFF
--- a/ci-scripts/lib.sh
+++ b/ci-scripts/lib.sh
@@ -130,44 +130,70 @@ capture_nightly_build_info() {
 
     # Defaults
     local image_digest="unknown" image_created="unknown"
-    local build_release="unknown" build_version="unknown" os_git_commit="unknown"
+    local build_release="unknown" build_version="unknown"
+    local pipelines_controller_git_commit="unknown"
 
     if [ "$catalog_image" != "unknown" ]; then
         local image_info_json
         image_info_json=$(oc image info "$catalog_image" --filter-by-os=linux/amd64 -o json 2>/dev/null || echo "")
 
         if [ -n "$image_info_json" ]; then
-            read -r image_digest image_created build_release build_version os_git_commit <<<"$(
+            read -r image_digest image_created build_release build_version <<<"$(
               echo "$image_info_json" | jq -r '
                 [
                   .digest // "unknown",
                   .config.created // .config.config.Labels["build-date"] // "unknown",
                   (.config.config.Env[] | select(startswith("BUILD_RELEASE=")) | split("=")[1]) // "unknown",
-                  (.config.config.Env[] | select(startswith("BUILD_VERSION=")) | split("=")[1]) // "unknown",
-                  (.config.config.Env[] | select(startswith("OS_GIT_COMMIT=")) | split("=")[1]) // "unknown"
+                  (.config.config.Env[] | select(startswith("BUILD_VERSION=")) | split("=")[1]) // "unknown"
                 ] | @tsv
               '
             )"
         fi
     fi
 
-    # Deployment context
-    local deployment_type="${DEPLOYMENT_TYPE:-unknown}"
-    local deployment_version="${DEPLOYMENT_VERSION:-unknown}"
-    local is_nightly_build="${NIGHTLY_BUILD:-false}"
+    local controller_image
+    controller_image=$(
+        oc -n openshift-pipelines get deploy tekton-pipelines-controller \
+            -o jsonpath='{.spec.template.spec.containers[?(@.name=="tekton-pipelines-controller")].image}' \
+            2>/dev/null
+    ) || true
+    
+    controller_image="${controller_image#"${controller_image%%[![:space:]]*}"}"
+    controller_image="${controller_image%"${controller_image##*[![:space:]]}"}"
+
+    if [ -n "$controller_image" ] && [ "$controller_image" != "null" ]; then
+        local controller_image_info_json
+        controller_image_info_json=$(
+            oc image info "$controller_image" --filter-by-os=linux/amd64 -o json 2>/dev/null
+        ) || true
+        if [ -n "$controller_image_info_json" ]; then
+            pipelines_controller_git_commit=$(
+                echo "$controller_image_info_json" | jq -r '
+                    (.config.config.Labels // {}) as $L |
+                    $L["upstream-vcs-ref"] // empty
+                ' 2>/dev/null
+            )
+            [ -z "$pipelines_controller_git_commit" ] && pipelines_controller_git_commit="unknown"
+        fi
+    fi
+
+    # Short SHA (7 chars) for upstream Pipelines revision
+    if [ "$pipelines_controller_git_commit" != "unknown" ]; then
+        pipelines_controller_git_commit="${pipelines_controller_git_commit:0:7}"
+    fi
 
     # JSON struct
     local deployment_info_entry
     deployment_info_entry=$(jq -n \
-        --arg deployment_type "$deployment_type" \
-        --arg deployment_version "$deployment_version" \
-        --arg is_nightly_build "$is_nightly_build" \
+        --arg deployment_type "${DEPLOYMENT_TYPE:-unknown}" \
+        --arg deployment_version "${DEPLOYMENT_VERSION:-unknown}" \
+        --arg is_nightly_build "${NIGHTLY_BUILD:-false}" \
         --arg image "$catalog_image" \
         --arg digest "$image_digest" \
         --arg created "$image_created" \
         --arg build_release "$build_release" \
         --arg build_version "$build_version" \
-        --arg os_git_commit "$os_git_commit" \
+        --arg pipelines_controller_git_commit "$pipelines_controller_git_commit" \
         '{
             type: $deployment_type,
             version: $deployment_version,
@@ -178,7 +204,7 @@ capture_nightly_build_info() {
                 created: $created,
                 build_release: $build_release,
                 build_version: $build_version,
-                os_git_commit: $os_git_commit
+                pipelines_controller_git_commit: $pipelines_controller_git_commit
             }
         }')
 

--- a/ci-scripts/prow-to-storage.sh
+++ b/ci-scripts/prow-to-storage.sh
@@ -4,17 +4,17 @@ CACHE_DIR="prow-to-es-cache-dir"
 DRY_RUN=false
 DEBUG=true
 
-PROW_JOBS=(
-    "max-concurrency-downstream-nightly-daily"
-    "max-concurrency-downstream-nightly-daily-ha-10"
-    "max-concurrency-downstream-nightly-daily-ha-10-state"
-    "max-concurrency-downstream-pipelines1-19-daily"
-    "max-concurrency-downstream-pipelines1-19-daily-ha-10"
-    "max-concurrency-downstream-pipelines1-19-daily-ha-10-state"
-    "max-concurrency-downstream-pipelines1-20-daily"
-    "max-concurrency-downstream-pipelines1-20-daily-ha-10"
-    "max-concurrency-downstream-pipelines1-20-daily-ha-10-state"
-)
+_PROW_VARIANT_SUFFIXES=("" "-ha-10" "-ha-10-state" "-qbt" "-ha-10-qbt")
+PROW_JOBS=()
+for sfx in "${_PROW_VARIANT_SUFFIXES[@]}"; do
+    PROW_JOBS+=( "max-concurrency-downstream-nightly${sfx}" )
+done
+for pv in 19 20 21; do
+    for sfx in "${_PROW_VARIANT_SUFFIXES[@]}"; do
+        PROW_JOBS+=( "max-concurrency-downstream-pipelines1-${pv}${sfx}" )
+    done
+done
+unset _PROW_VARIANT_SUFFIXES
 
 [ -e script-mate/ ] || git clone --depth=1 https://github.com/redhat-performance/script-mate.git
 source script-mate/src/opl_shovel.sh
@@ -32,8 +32,12 @@ for prow_run in "${PROW_JOBS[@]}"; do
             out="$CACHE_DIR/$i-$subjob.benchmark-tekton.json"
             prow_download "$prow_job" "$i" "$prow_run" "$job_path/$subjob/$subjob_file" "$out" "jobLink"
             check_json "$out" || continue
-            jq '.started = .results.started | .ended = .results.ended' "$out" >"$$.json" && mv -f "$$.json" "$out"   # put started and ended dates to expected places
-            jq '.metadata.env.SUBJOB_BUILD_ID = .metadata.env.BUILD_ID + "'"$subjob"'"' "$out" >"$$.json" && mv -f "$$.json" "$out"   # generate unique subjob ID
+            jq --arg sj "$subjob" \
+                '.started = .results.started
+                | .ended = .results.ended
+                | .metadata.env.SUBJOB_BUILD_ID = .metadata.env.BUILD_ID + $sj' \
+                "$out" >"${out}.tmp" && mv -f "${out}.tmp" "$out" \
+                || { rm -f "${out}.tmp"; false; }
             json_complete "$out" || continue
             enritch_stuff "$out" '."$schema"' "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
             horreum_upload "$out" "metadata.env.SUBJOB_BUILD_ID" "__metadata_env_SUBJOB_BUILD_ID" "Openshift-pipelines-team" "PUBLIC" || ((errors_count+=1))

--- a/tools/horreum_pipeline_fields.yaml
+++ b/tools/horreum_pipeline_fields.yaml
@@ -95,7 +95,7 @@ test:
   owner: "Openshift-pipelines-team"
   name: "OpenShift Pipelines scalingPipelines test"
   folder: "Openshift-pipelines"
-  description: "Results of this Prow job: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly-daily/"
+  description: "Results of this Prow job: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly/"
   datastoreId: 1  # Assuming default datastore
   timelineLabels: ["started"]
   timelineFunction: "value => new Date(value).getTime()"
@@ -137,6 +137,13 @@ fields:
   - name: "deployment_version"
     jsonpath: "$.deployment.version"
     description: "deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightlyBuild_pipelinesControllerGitCommit"
+    jsonpath: "$.deployment.nightly_build.pipelines_controller_git_commit"
+    description: "Upstream tektoncd/pipeline git SHA (controller image upstream-vcs-ref)"
     filtering: true
     metrics: false
     change_detection_group: null


### PR DESCRIPTION
## Summary
Expands Prow job coverage to include Pipelines 1.21 and QBT variants. Also tracks the upstream tektoncd/pipeline git commit SHA from the controller image.

## Sample JSON
```json
"deployment": {
  "type": "downstream",
  "is_nightly_build": true,
  "nightly_build": {
    "image": "quay.io/openshift-pipeline/pipelines-index-4.20:next",
    "digest": "sha256:e542804e4c753f37573dc854bd14a409d2c2351bee057d34b6aa4bc01960aebc",
    "build_release": "202603300550.p2.g72a01f6.assembly.stream.el9",
    "build_version": "v4.20.0",
    "pipelines_controller_git_commit": "ec20509"
  },
}
```