### PR TITLE
  fix: add operator readiness checks and improve timeout handling for CI

### DIFF
--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -820,25 +820,46 @@ if [ "$RUN_LOCUST" == "true" ]; then
 
     # Check if the Helm release already exists, and install it if it doesn't
     if ! helm list --namespace "${LOCUST_NAMESPACE}" | grep -q "${LOCUST_OPERATOR}"; then
-        helm install "${LOCUST_OPERATOR}" locust-k8s-operator/locust-k8s-operator --namespace "${LOCUST_NAMESPACE}" -f "$LOCUST_HELM_CONFIG"
+        info "Installing Locust operator via Helm (with --wait, timeout 10m)..."
+        if ! helm install "${LOCUST_OPERATOR}" locust-k8s-operator/locust-k8s-operator --namespace "${LOCUST_NAMESPACE}" -f "$LOCUST_HELM_CONFIG" --wait --timeout 10m; then
+            warning "Helm install failed, collecting diagnostics..."
+            kubectl -n "${LOCUST_NAMESPACE}" get all || true
+            kubectl -n "${LOCUST_NAMESPACE}" get events --sort-by='.lastTimestamp' | tail -30 || true
+            fatal "Locust operator Helm installation failed"
+        fi
+        info "Helm install completed successfully"
     else
         info "Helm release \"${LOCUST_OPERATOR}\" already exists"
     fi
 
-    # Wait for the operator deployment to be rolled out (label-agnostic; CI can be slow to pull images).
-    # Helm may take a moment to create the deployment; wait for it then for rollout.
-    info "Waiting for locust-operator deployment to appear..."
-    for _ in $(seq 1 30); do
+    # Verify deployment exists and show initial status
+    info "Verifying locust-operator deployment..."
+    for i in $(seq 1 30); do
         LOCUST_DEPLOY=$(kubectl get deploy -n "${LOCUST_NAMESPACE}" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-        [[ -n "${LOCUST_DEPLOY}" ]] && break
+        if [[ -n "${LOCUST_DEPLOY}" ]]; then
+            info "Found deployment: ${LOCUST_DEPLOY}"
+            kubectl -n "${LOCUST_NAMESPACE}" get deployment "${LOCUST_DEPLOY}" -o wide || true
+            kubectl -n "${LOCUST_NAMESPACE}" get pods -l "app.kubernetes.io/name=locust-k8s-operator" -o wide || true
+            break
+        fi
+        info "Deployment not found yet, waiting... (attempt $i/30)"
         sleep 2
     done
+
     if [[ -n "${LOCUST_DEPLOY}" ]]; then
-        info "Waiting for deployment/${LOCUST_DEPLOY} rollout (timeout 300s)"
-        kubectl rollout status "deployment/${LOCUST_DEPLOY}" -n "${LOCUST_NAMESPACE}" --timeout=300s
+        info "Waiting for deployment/${LOCUST_DEPLOY} rollout (timeout 600s)"
+        if ! kubectl rollout status "deployment/${LOCUST_DEPLOY}" -n "${LOCUST_NAMESPACE}" --timeout=600s; then
+            warning "Locust operator deployment failed to rollout, collecting diagnostics..."
+            kubectl -n "${LOCUST_NAMESPACE}" get pods -o wide || true
+            kubectl -n "${LOCUST_NAMESPACE}" describe deployment "${LOCUST_DEPLOY}" || true
+            kubectl -n "${LOCUST_NAMESPACE}" describe pods -l "app.kubernetes.io/name=locust-k8s-operator" || true
+            kubectl -n "${LOCUST_NAMESPACE}" get events --sort-by='.lastTimestamp' | tail -30 || true
+            fatal "Locust operator deployment failed to become ready"
+        fi
+        info "Locust operator deployment is ready"
     else
-        # Fallback: wait for pod by label (chart may use app.kubernetes.io/name=locust-k8s-operator or similar)
-        wait_for_entity_by_selector 300 "${LOCUST_NAMESPACE}" pod "app.kubernetes.io/name=locust-k8s-operator"
+        warning "Could not find locust-operator deployment, trying fallback wait..."
+        wait_for_entity_by_selector 600 "${LOCUST_NAMESPACE}" pod "app.kubernetes.io/name=locust-k8s-operator"
     fi
 
     info "Enabling user workload monitoring"

--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -542,6 +542,7 @@ EOF
         fi
 
         wait_for_entity_by_selector 300 openshift-operators-redhat pod name=loki-operator-controller-manager
+        kubectl -n openshift-operators-redhat wait --for=condition=ready --timeout=300s pod -l name=loki-operator-controller-manager
 
         # Create OperatorGroup for installing openshift-logging
         cat <<EOF | oc apply -f -
@@ -585,6 +586,7 @@ spec:
 EOF
 
         wait_for_entity_by_selector 300 openshift-logging pod name=cluster-logging-operator
+        kubectl -n openshift-logging wait --for=condition=ready --timeout=300s pod -l name=cluster-logging-operator
 
         default_storage_class=$(kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
 


### PR DESCRIPTION

  ## Summary
  Fixes operator installation failures in CI by adding proper readiness checks and timeout improvements
  for Loki, cluster-logging, and Locust operators.

  ## Problem
  CI jobs for both 1.20 and 1.21 were failing during cluster setup with:
  - **Loki operator**: `no endpoints available for service 'loki-operator-controller-manager-service'`
  When creating LokiStack
  - **Locust operator**: `timed out waiting for the condition` - deployment stuck at "0 out of 2 new
  replicas updated" after 300s

  Root cause: Scripts were creating resources before operator webhooks were fully ready, and the timeouts
  were too short for slow CI image pulls.

  ## Changes

  ### 1. Loki & Cluster-Logging Operators
  - Added `kubectl wait --for=condition=ready` after pod existence checks (lines 545, 589)
  - Ensures webhook services have endpoints before creating dependent resources

  ### 2. Locust Operator
  - Added `helm install --wait --timeout 10m` for synchronous deployment
  - Increased rollout timeout from 300s → 600s to handle slow image pulls
  - Added comprehensive diagnostics on failure (pods, deployment, events)
  - Improved progress logging

  ## Testing
Tested on a temporary OpenShift cluster (OCP 4.17)
  - All operators installed successfully
  - Locust operator deployed in ~58s with new code
  - Diagnostics work correctly

  ## Impact
  - Fixes CI failures for both downstream 1.20 and 1.21 test jobs
  - No impact on successful runs (just better logging)
  - Provides actionable diagnostics when failures occur

  ## Related Issues
  - Fixes: rehearse-74988 CI failures for tkn-res-downstream-1-20/1-21-s3-locust tests
  - Build logs: [1.21](https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_release/74988/rehearse-74988-pull-ci-openshift-pipelines-performance-main-tkn-res-downstream-1-21-s3-locust-2-lsr/2046671103874568192/build-log.txt) | [1.20](https://storage.googleapis.com/test-platform-results/pr-logs/pull/openshift_release/74988/rehearse-74988-pull-ci-openshift-pipelines-performance-main-tkn-res-downstream-1-20-s3-locust-2-lsr/2046671103811653632/build-log.txt)