### PR TITLE
fix: configure Locust operator for OpenShift SCC compatibility without manual grants

### DIFF
--- a/ci-scripts/setup-cluster.sh
+++ b/ci-scripts/setup-cluster.sh
@@ -811,10 +811,6 @@ if [ "$RUN_LOCUST" == "true" ]; then
     # Create namespace if not exists
     oc get ns "${LOCUST_NAMESPACE}" || oc create ns "${LOCUST_NAMESPACE}"
 
-    # Grant nonroot SCC to default service account for OpenShift compatibility
-    info "Granting nonroot SCC to service account in ${LOCUST_NAMESPACE}"
-    oc adm policy add-scc-to-user nonroot -z default -n "${LOCUST_NAMESPACE}" || true
-
     # Check if the Helm repo already exists, and add it if it doesn't
     if ! helm repo list --namespace "${LOCUST_NAMESPACE}" | grep -q "${LOCUST_OPERATOR_REPO}"; then
         helm repo add "${LOCUST_OPERATOR_REPO}" https://abdelrhmanhamouda.github.io/locust-k8s-operator/ --namespace "${LOCUST_NAMESPACE}"

--- a/config/locust-k8s-operator.values.yaml
+++ b/config/locust-k8s-operator.values.yaml
@@ -3,10 +3,22 @@ image:
   tag: "latest"
   pullPolicy: Always
 
-# OpenShift compatibility: Override security context to allow SCC assignment
-# OpenShift will assign UID/GID from the namespace's allowed range
-securityContext: {}
-podSecurityContext: {}
+# OpenShift compatibility: Let restricted-v2 SCC assign UID/GID dynamically
+# Do not set runAsUser/fsGroup - OpenShift will inject namespace-allocated IDs
+# Only set runAsNonRoot to satisfy security requirements
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  # Explicitly do NOT set runAsUser - let OpenShift SCC assign it
 
 k8s:
   clusterRole:


### PR DESCRIPTION
Configure security context to work with OpenShift's restricted-v2 SCC without requiring manual 'oc adm policy add-scc-to-user' commands.

Changes:
- Set runAsNonRoot: true in pod and container security contexts
- DO NOT set explicit runAsUser/fsGroup - let OpenShift SCC inject them
- Add security hardening: drop all capabilities, disable privilege escalation, read-only root filesystem, RuntimeDefault seccomp profile

How it works:
- Locust operator image has hardcoded UID 65532
- OpenShift restricted-v2 SCC sees runAsNonRoot=true without explicit runAsUser
- SCC automatically injects namespace-allocated UID (e.g., 1000810000)
- Pod runs with OpenShift-assigned UID, overriding image default
- No manual SCC grants needed - works with default cluster security policies

This resolves CI failures where Locust operator deployment was rejected due to fsGroup/runAsUser 65532 being outside allowed namespace range.
