### PR TITLE
fix: use correct Helm values key for container security context

### DIFF
--- a/config/locust-k8s-operator.values.yaml
+++ b/config/locust-k8s-operator.values.yaml
@@ -11,7 +11,7 @@ podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-securityContext:
+containerSecurityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:


### PR DESCRIPTION
PR #88 used 'securityContext' but the Helm chart v2.2.0 expects 'containerSecurityContext'. This caused the override to be silently ignored, leaving the image's hardcoded UID 65532 which falls outside OpenShift's namespace-allocated UID range.


Generated-by: Claude