### PR TITLE
fix: disable Locust operator webhook to prevent CrashLoopBackOff

### DIFF
--- a/config/locust-k8s-operator.values.yaml
+++ b/config/locust-k8s-operator.values.yaml
@@ -5,6 +5,11 @@ image:
   tag: ""  # Use chart default appVersion
   pullPolicy: IfNotPresent
 
+# Disable webhook - requires cert-manager for TLS certs which isn't installed
+# Webhook is only needed for v1->v2 API compatibility (we only use v2)
+webhook:
+  enabled: false
+
 # OpenShift SCC compatibility: Explicitly override Helm chart v2.1.1 hardcoded defaults
 # Chart has runAsUser/runAsGroup/fsGroup: 65532 which violates OpenShift SCC ranges
 # Setting to null removes these hardcoded values and allows OpenShift to inject dynamic IDs

--- a/tests/scaling-pipelines/scenario/common/locust-test-template.yaml
+++ b/tests/scaling-pipelines/scenario/common/locust-test-template.yaml
@@ -1,17 +1,20 @@
-apiVersion: locust.io/v1
+apiVersion: locust.io/v2
 kind: LocustTest
 metadata:
   name: ${SCENARIO}.test
 spec:
   image: quay.io/backstage-performance/locust:latest
   imagePullPolicy: Always
-  masterCommandSeed: --locustfile /lotest/src/${SCENARIO}.py
-    --host ${LOCUST_HOST}
-    --users ${LOCUST_USERS}
-    --spawn-rate ${LOCUST_SPAWN_RATE}
-    --run-time ${LOCUST_DURATION}
-    ${LOCUST_EXTRA_CMD}
-  workerCommandSeed: --locustfile /lotest/src/${SCENARIO}.py
-    ${LOCUST_EXTRA_CMD}
-  workerReplicas: ${LOCUST_WORKERS}
-  configMap: locust.${SCENARIO}
+  master:
+    command: --locustfile /lotest/src/${SCENARIO}.py
+      --host ${LOCUST_HOST}
+      --users ${LOCUST_USERS}
+      --spawn-rate ${LOCUST_SPAWN_RATE}
+      --run-time ${LOCUST_DURATION}
+      ${LOCUST_EXTRA_CMD}
+  worker:
+    command: --locustfile /lotest/src/${SCENARIO}.py
+      ${LOCUST_EXTRA_CMD}
+    replicas: ${LOCUST_WORKERS}
+  testFiles:
+    configMapRef: locust.${SCENARIO}


### PR DESCRIPTION
The Locust operator was crashing with error:
  "open /tmp/k8s-webhook-server/serving-certs/tls.crt: no such file or directory"

Here is the latest CI failure log : https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/78447/rehearse-78447-pull-ci-openshift-pipelines-performance-main-tkn-res-downstream-1-21-s3-locust-2-lsr/2049034471239323648

Root cause: The webhook server requires cert-manager to provision TLS certificates, but cert-manager is not installed in the cluster.

So I disabled the webhook as it's only needed for v1->v2 API compatibility. Since we only use v2 LocustTest CRs, the webhook is not required.
