### PR TITLE
fix: add OTEL metric fallbacks for Tekton >= v1.10

### DIFF
--- a/config/cluster_read_config.yaml
+++ b/config/cluster_read_config.yaml
@@ -83,7 +83,7 @@
   monitoring_query: |
     sum(tekton_pipelines_controller_workqueue_depth)
     or
-    sum(kn_workqueue_depth)
+    sum(kn_workqueue_depth{container='tekton-pipelines-controller'})
   monitoring_step: 15
 
 - name: measurements.tekton_tekton_chains_controller_workqueue_depth
@@ -106,7 +106,7 @@
   monitoring_query: |
     (sum(rate(tekton_pipelines_controller_client_latency_sum[1m])) / sum(rate(tekton_pipelines_controller_client_latency_count[1m])) > 0)
     or
-    (sum(rate(http_client_request_duration_seconds_sum[1m])) / sum(rate(http_client_request_duration_seconds_count[1m])) > 0)
+    (sum(rate(http_client_request_duration_seconds_sum{container='tekton-pipelines-controller'}[1m])) / sum(rate(http_client_request_duration_seconds_count{container='tekton-pipelines-controller'}[1m])) > 0)
   monitoring_step: 15
 
 - name: measurements.tekton_pipelines_controller_taskruns_pod_latency_milliseconds

--- a/config/cluster_read_config.yaml
+++ b/config/cluster_read_config.yaml
@@ -80,7 +80,10 @@
   monitoring_step: 15
 
 - name: measurements.tekton_tekton_pipelines_controller_workqueue_depth
-  monitoring_query: sum(tekton_pipelines_controller_workqueue_depth)
+  monitoring_query: |
+    sum(tekton_pipelines_controller_workqueue_depth)
+    or
+    sum(kn_workqueue_depth)
   monitoring_step: 15
 
 - name: measurements.tekton_tekton_chains_controller_workqueue_depth
@@ -100,7 +103,10 @@
   monitoring_step: 15
 
 - name: measurements.tekton_pipelines_controller_client_latency_average
-  monitoring_query: sum(rate(tekton_pipelines_controller_client_latency_sum[1m]) / rate(tekton_pipelines_controller_client_latency_count[1m]))
+  monitoring_query: |
+    (sum(rate(tekton_pipelines_controller_client_latency_sum[1m])) / sum(rate(tekton_pipelines_controller_client_latency_count[1m])) > 0)
+    or
+    (sum(rate(http_client_request_duration_seconds_sum[1m])) / sum(rate(http_client_request_duration_seconds_count[1m])) > 0)
   monitoring_step: 15
 
 - name: measurements.tekton_pipelines_controller_taskruns_pod_latency_milliseconds


### PR DESCRIPTION
## Summary

- Tekton v1.10+ migrated from OpenCensus to OpenTelemetry, renaming Prometheus metrics (`tekton_pipelines_controller_workqueue_depth` → `kn_workqueue_depth`, `tekton_pipelines_controller_client_latency` → `http_client_request_duration_seconds`).
- Added PromQL `or` fallbacks in `cluster_read_config.yaml` so both old and new metric names are supported seamlessly.
 
## Changes

### `config/cluster_read_config.yaml`
- **`workqueue_depth`**: Falls back to `sum(kn_workqueue_depth)` when `tekton_pipelines_controller_workqueue_depth` is absent.
- **`client_latency_average`**: Falls back to `sum(rate(http_client_request_duration_seconds_sum)) / sum(rate(http_client_request_duration_seconds_count))` (mean). Both sides filter `> 0` to avoid `NaN` blocking the `or` operator.

## Why

Clusters running Tekton >= v1.10 (including v1.11.0 used in nightly CI) no longer emit OpenCensus metrics, causing `workqueue_depth` and `client_latency` to return empty results. These fallbacks ensure metrics are collected regardless of the Tekton version.
