### PR TITLE
feat: add Chains signing test integration and reorganize horreum tooling

### DIFF
--- a/ci-scripts/lib.sh
+++ b/ci-scripts/lib.sh
@@ -225,15 +225,15 @@ capture_ha_qbt_config() {
     info "Collecting HA and QBT configuration information"
 
     (cat "$output_file" 2>/dev/null || echo "{}") | jq \
-        --arg ha_pipelines "${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-0}" \
+        --arg ha_replicas "${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-${DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS:-0}}" \
         --arg controller_type "${DEPLOYMENT_PIPELINES_CONTROLLER_TYPE:-deployments}" \
-        --arg qps "${DEPLOYMENT_PIPELINES_KUBE_API_QPS:-}" \
-        --arg burst "${DEPLOYMENT_PIPELINES_KUBE_API_BURST:-}" \
-        --arg threads "${DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER:-}" \
+        --arg qps "${DEPLOYMENT_PIPELINES_KUBE_API_QPS:-${DEPLOYMENT_CHAINS_KUBE_API_QPS:-}}" \
+        --arg burst "${DEPLOYMENT_PIPELINES_KUBE_API_BURST:-${DEPLOYMENT_CHAINS_KUBE_API_BURST:-}}" \
+        --arg threads "${DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER:-${DEPLOYMENT_CHAINS_THREADS_PER_CONTROLLER:-}}" \
         --arg ocp_version "${OCP_VERSION:-$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null | cut -d. -f1,2)}" \
         '.deployment.ha_config = {
-            ha_enabled: (($ha_pipelines | tonumber) > 0),
-            ha_replicas: ($ha_pipelines | tonumber),
+            ha_enabled: (($ha_replicas | tonumber) > 0),
+            ha_replicas: ($ha_replicas | tonumber),
             controller_type: $controller_type
         } |
         .deployment.qbt_config = {
@@ -252,15 +252,23 @@ capture_scenario_name() {
 
     info "Generating scenario descriptive name"
 
+    local controller_label
+    local base_name
+    if [[ "${TEST_SCENARIO:-}" == *signing* ]]; then
+        base_name="Chains controller signing performance"
+    else
+        base_name="Pipelines controller with rising concurrency"
+    fi
+
     local scenario_name
     scenario_name=$(jq -n \
-        --arg ha_replicas "${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-0}" \
+        --arg base "$base_name" \
+        --arg ha_replicas "${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-${DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS:-0}}" \
         --arg controller_type "${DEPLOYMENT_PIPELINES_CONTROLLER_TYPE:-deployments}" \
-        --arg qps "${DEPLOYMENT_PIPELINES_KUBE_API_QPS:-}" \
-        --arg burst "${DEPLOYMENT_PIPELINES_KUBE_API_BURST:-}" \
-        --arg threads "${DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER:-}" \
+        --arg qps "${DEPLOYMENT_PIPELINES_KUBE_API_QPS:-${DEPLOYMENT_CHAINS_KUBE_API_QPS:-}}" \
+        --arg burst "${DEPLOYMENT_PIPELINES_KUBE_API_BURST:-${DEPLOYMENT_CHAINS_KUBE_API_BURST:-}}" \
+        --arg threads "${DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER:-${DEPLOYMENT_CHAINS_THREADS_PER_CONTROLLER:-}}" \
         -r '
-        "Pipelines controller with rising concurrency" as $base |
         [] |
         if ($ha_replicas | tonumber) > 0 then . + ["HA=\($ha_replicas)"] else . end |
         if $controller_type == "statefulsets" then . + ["statefulsets"] else . end |

--- a/tools/horreum/README.md
+++ b/tools/horreum/README.md
@@ -1,0 +1,154 @@
+# Horreum Integration
+
+This directory (`tools/horreum/`) contains configuration and tooling for managing [Horreum](https://horreum.hyperfoil.io/) test definitions, schema labels, and change detection variables for OpenShift Pipelines performance tests.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `run_horreum_integration.sh` | Wrapper script that invokes `horreum_api.py` with env validation and defaults |
+| `horreum_pipeline_fields.yaml` | Horreum config for the **Pipelines** test (`OpenShift Pipelines scalingPipelines test`) |
+| `horreum_chains_fields.yaml` | Horreum config for the **Chains** test (`OpenShift Pipelines Chains signing test`) |
+
+## Architecture
+
+Both tests **share the same Horreum schema** (`urn:openshift-pipelines-perfscale-scalingPipelines:0.2`) since labels live on the schema, not the test. Each YAML defines its own:
+
+- **Test** — separate Horreum test with its own name, fingerprint labels, and description
+- **Labels** — subset of schema labels relevant to that test type
+- **Change detection groups (CDGs)** — variables that trigger regression alerts
+
+```
+┌─────────────────────────────────────────────────┐
+│          Shared Schema                          │
+│  urn:openshift-pipelines-perfscale-...          │
+│                                                 │
+│  Labels from Pipelines YAML ──┐                 │
+│  Labels from Chains YAML ─────┤ (union on       │
+│                               │  shared schema) │
+├───────────────────┬───────────┴─────────────────┤
+│ Pipelines Test    │ Chains Test                 │
+│ - own CDGs        │ - own CDGs                  │
+│ - own fingerprint │ - own fingerprint           │
+│ - own variables   │ - own variables             │
+└───────────────────┴─────────────────────────────┘
+```
+
+## Usage
+
+### Prerequisites
+
+Install OPL extras (provides `horreum_api.py`):
+
+```bash
+pip install "git+https://github.com/redhat-performance/opl.git#subdirectory=extras&egg=opl-rhcloud-perf-team-extras"
+```
+
+### Required environment variables
+
+```bash
+export HORREUM_URL="https://your-horreum-instance"
+export HORREUM_API_KEY="HUSR_00000000_0000_0000_0000_000000000000"
+```
+
+### Running
+
+```bash
+# Dry-run (default) — preview changes without applying
+./tools/horreum/run_horreum_integration.sh
+
+# Execute changes
+./tools/horreum/run_horreum_integration.sh --execute
+
+# Use a specific config file
+./tools/horreum/run_horreum_integration.sh -c tools/horreum/horreum_chains_fields.yaml
+```
+
+### Multi-test setup
+
+Since both YAMLs share the same schema, the script must be run **twice** with `CLEANUP_LABELS=false` to prevent one invocation from deleting the other test's labels:
+
+```bash
+export CLEANUP_LABELS=false
+
+# Configure Pipelines test
+./tools/horreum/run_horreum_integration.sh -c tools/horreum/horreum_pipeline_fields.yaml --execute
+
+# Configure Chains test
+./tools/horreum/run_horreum_integration.sh -c tools/horreum/horreum_chains_fields.yaml --execute
+```
+
+> **Warning:** With `CLEANUP_LABELS=false`, removing a label from a YAML file will **not** delete it from Horreum. Stale labels must be removed manually via the Horreum UI if needed.
+
+## YAML structure
+
+Each YAML file follows this structure:
+
+```yaml
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+change_detection_defaults:
+  model: "relativeDifference"
+  window: 10
+  min_previous: 5
+  threshold: 0.10
+
+change_detection_groups:
+  "group_name":
+    description: "What this group monitors"
+    model: "relativeDifference"    # or "fixedThreshold"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+test:
+  name: "Test name (must match the 'name' field in benchmark-tekton.json)"
+  owner: "Openshift-pipelines-team"
+  folder: "Openshift-pipelines"
+  fingerprintLabels:
+    - label_name_1
+    - label_name_2
+
+schema:
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+
+fields:
+  - name: "label_name"
+    jsonpath: "$.path.in.benchmark.tekton.json"
+    description: "Human-readable description"
+    filtering: true              # available as a filter in Horreum UI
+    metrics: true                # tracked as a metric
+    change_detection_group: "group_name"  # null = no alerting
+```
+
+## Change detection models
+
+| Model | Use case | Key parameters |
+|---|---|---|
+| `relativeDifference` | Performance metrics (CPU, memory, duration, throughput) | `threshold` (e.g. 0.10 = 10% change triggers alert) |
+| `fixedThreshold` | Counts that must be exact (failures = 0, restarts = 0) | `min_value`, `max_value`, `min_enabled`, `max_enabled` |
+
+## Fingerprint labels
+
+Fingerprint labels partition data so Horreum compares like-for-like runs. Each test uses different fingerprints:
+
+**Pipelines test:**
+- `deployment_haConfig_haEnabled`, `deployment_version`, `parameters_test_total`, `parameters_test_concurrent`, `deployment_haConfig_controllerType`, `deployment_qbtConfig_qbtEnabled`
+
+**Chains test:**
+- `deployment_haConfig_haEnabled`, `deployment_version`, `parameters_test_total`, `deployment_qbtConfig_qbtEnabled`, `metadata_env_TEST_SCENARIO`
+
+Chains omits `parameters_test_concurrent` (always 20) and `deployment_haConfig_controllerType` (always "deployments"), and adds `metadata_env_TEST_SCENARIO` to distinguish signing scenarios.
+
+## How the `name` field connects everything
+
+The `name` field in `benchmark-tekton.json` determines which Horreum test receives the data:
+
+- `stats.sh` sets the name based on `TEST_SCENARIO`:
+  - `*signing*` → `"OpenShift Pipelines Chains signing test"`
+  - Otherwise → `"OpenShift Pipelines scalingPipelines test"`
+- `prow-to-storage.sh` uploads the JSON to Horreum, which routes it by matching `@name`
+- The Horreum test name in the YAML must match exactly

--- a/tools/horreum/horreum_chains_fields.yaml
+++ b/tools/horreum/horreum_chains_fields.yaml
@@ -1,0 +1,607 @@
+# Horreum Fields Configuration — Chains Test
+# Shares the same schema as Pipelines (same URI), but has its own test definition
+# and change detection variables for Chains-specific metrics.
+#
+# IMPORTANT: Run with CLEANUP_LABELS=false to avoid deleting Pipelines labels
+# from the shared schema.
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"
+  window: 10
+  min_previous: 5
+  threshold: 0.10
+
+# Change detection groups for Chains test
+change_detection_groups:
+  "chains_cpu":
+    description: "Chains controller CPU metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+    model: "relativeDifference"
+
+  "chains_memory":
+    description: "Chains controller memory metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "chains_workqueue":
+    description: "Chains controller workqueue depth"
+    threshold: 0.20
+    window: 5
+    min_previous: 5
+
+  "signing_throughput":
+    description: "Signing duration and throughput metrics"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns (varies with TEST_TOTAL)"
+    model: "relativeDifference"
+    threshold: 0.01
+    window: 5
+    min_previous: 3
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns (varies with TEST_TOTAL)"
+    model: "relativeDifference"
+    threshold: 0.01
+    window: 5
+    min_previous: 3
+
+  "PipelineRuns_TaskRuns_Failed_count":
+    description: "Number of failing PipelineRuns and TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "signing_count":
+    description: "All runs must be signed (varies with TEST_TOTAL)"
+    model: "relativeDifference"
+    threshold: 0.01
+    window: 5
+    min_previous: 3
+
+  "signing_unsigned_count":
+    description: "No runs should remain unsigned"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+# Test definition — Chains-specific
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "OpenShift Pipelines Chains signing test"
+  folder: "Openshift-pipelines"
+  description: "Chains signing performance test results"
+  datastoreId: 1
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_total
+    - deployment_qbtConfig_qbtEnabled
+    - metadata_env_TEST_SCENARIO
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition — SAME as Pipelines (shared schema)
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+# Includes shared labels (same as Pipelines) + Chains-specific labels
+fields:
+  # =========================================================================
+  # Shared labels (also in horreum_pipeline_fields.yaml)
+  # =========================================================================
+
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. signing-tr-tekton-bigbang)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_PipelineRuns_count_failed"
+    jsonpath: "$.results.PipelineRuns.count.failed"
+    description: "Number of failed PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_failed"
+    jsonpath: "$.results.TaskRuns.count.failed"
+    description: "Number of failed TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # =========================================================================
+  # Chains-specific labels
+  # =========================================================================
+
+  # Chains controller CPU
+  - name: "measurements_tektonChainsController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_cpu"
+
+  - name: "measurements_tektonChainsController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_cpu"
+
+  # Chains controller memory
+  - name: "measurements_tektonChainsController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.mean"
+    description: "Mean memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_memory"
+
+  - name: "measurements_tektonChainsController_memory_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.max"
+    description: "Maximum memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_memory"
+
+  # Chains controller restarts
+  - name: "measurements_tektonChainsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".restarts.range"
+    description: "tekton-chains-controller restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  # Chains controller workqueue depth
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.mean"
+    description: "Mean Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_workqueue"
+
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_max"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.max"
+    description: "Maximum Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_workqueue"
+
+  # Signing metrics — PipelineRuns
+  - name: "results_PipelineRuns_signing_count_signed_true"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_true"
+    description: "Number of PipelineRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_PipelineRuns_signing_count_signed_false"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_false"
+    description: "Number of PipelineRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_count_unsigned"
+    jsonpath: "$.results.PipelineRuns.signing.count.unsigned"
+    description: "Number of PipelineRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_duration"
+    jsonpath: "$.results.PipelineRuns.signing.duration"
+    description: "PipelineRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"
+
+  - name: "results_PipelineRuns_signing_throughput"
+    jsonpath: "$.results.PipelineRuns.signing.throughput"
+    description: "PipelineRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"
+
+  # Signing metrics — TaskRuns
+  - name: "results_TaskRuns_signing_count_signed_true"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_true"
+    description: "Number of TaskRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_TaskRuns_signing_count_signed_false"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_false"
+    description: "Number of TaskRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_count_unsigned"
+    jsonpath: "$.results.TaskRuns.signing.count.unsigned"
+    description: "Number of TaskRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_duration"
+    jsonpath: "$.results.TaskRuns.signing.duration"
+    description: "TaskRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"
+
+  - name: "results_TaskRuns_signing_throughput"
+    jsonpath: "$.results.TaskRuns.signing.throughput"
+    description: "TaskRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"

--- a/tools/horreum/horreum_pipeline_fields.yaml
+++ b/tools/horreum/horreum_pipeline_fields.yaml
@@ -17,21 +17,21 @@ change_detection_defaults:
 # Change detection groups with specific configurations
 change_detection_groups:
   "cpu":
-    description: "High-impact metrics requiring immediate attention"
-    threshold: 0.10              # 5% threshold for critical metrics
+    description: "CPU metrics"
+    threshold: 0.10
     window: 5
     min_previous: 5
     model: "relativeDifference"
 
   "etcdMvccDb":
-    description: "Pipeline execution and timing metrics"
-    threshold: 0.10              # 8% threshold for pipeline metrics
+    description: "etcd database metrics"
+    threshold: 0.10
     window: 5
     min_previous: 5
 
   "memory":
-    description: "TaskRun execution and resource metrics"
-    threshold: 0.10              # 10% threshold for task metrics
+    description: "memory metrics"
+    threshold: 0.10
     window: 5
     min_previous: 5
 
@@ -67,8 +67,8 @@ change_detection_groups:
       min_enabled: false
 
   "PipelineRuns_TaskRuns_duration":
-    description: "Cluster and system-level performance metrics"
-    threshold: 0.20              # 20% threshold for system metrics
+    description: "PLRs/TRs duration metrics"
+    threshold: 0.20
     window: 10
     min_previous: 5
     model: "relativeDifference"
@@ -78,13 +78,13 @@ change_detection_groups:
     model: "fixedThreshold"
     fixed_threshold:
       max_enabled: true
-      max_value: 0               # Alert if ANY restart occurs
+      max_value: 0
       max_inclusive: true
       min_enabled: false
 
   "TaskRunsToPods_creation":
-    description: "etcd database and storage metrics"
-    threshold: 0.20              # 20% threshold for etcd metrics
+    description: "TaskRun-to-Pods creation lag"
+    threshold: 0.20
     window: 10
     min_previous: 5
     model: "relativeDifference"
@@ -247,49 +247,7 @@ fields:
     metrics: false
     change_detection_group: null
 
-  # cpu Metrics
-  - name: "measurements_apiserver_cpu_max"
-    jsonpath: "$.measurements.apiserver.cpu.max"
-    description: "Maximum CPU usage for API server"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"cpu"
-
-  - name: "measurements_apiserver_cpu_mean"
-    jsonpath: "$.measurements.apiserver.cpu.mean"
-    description: "Mean CPU usage for API server"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"cpu"
-
-  - name: "measurements_kubeApiserver_cpu_max"
-    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
-    description: "Maximum CPU usage for kube-apiserver"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"cpu"
-
-  - name: "measurements_kubeApiserver_cpu_mean"
-    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
-    description: "Mean CPU usage for kube-apiserver"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"cpu"
-
-  - name: "measurements_tektonOperatorProxyWebhook_cpu_mean"
-    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.mean"
-    description: "Mean CPU usage for tekton-operator-proxy-webhook"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"cpu"
-
-  - name: "measurements_tektonOperatorProxyWebhook_cpu_max"
-    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.max"
-    description: "Maximum CPU usage for tekton-operator-proxy-webhook"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"cpu"
-
+  # tekton-pipelines-controller
   - name: "measurements_tektonPipelinesController_cpu_mean"
     jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.mean"
     description: "Mean CPU usage for tekton-pipelines-controller"
@@ -304,6 +262,21 @@ fields:
     metrics: true
     change_detection_group: null #"cpu"
 
+  - name: "measurements_tektonPipelinesController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_tektonPipelinesController_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-pipelines-webhook
   - name: "measurements_tektonPipelinesWebhook_cpu_mean"
     jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.mean"
     description: "Mean CPU usage for tekton-pipelines-webhook"
@@ -318,6 +291,108 @@ fields:
     metrics: true
     change_detection_group: null #"cpu"
 
+  - name: "measurements_tektonPipelinesWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-operator-proxy-webhook
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # Cluster-level resource metrics
   - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
     jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
     description: "Mean total CPU usage rate across all cluster nodes"
@@ -346,6 +421,20 @@ fields:
     metrics: true
     change_detection_group: null #"cpu"
 
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
   - name: "measurements_apiserverRequestTotalRate_mean"
     jsonpath: "$.measurements.apiserver_request_total_rate.mean"
     description: "Mean API server request rate"
@@ -353,14 +442,7 @@ fields:
     metrics: true
     change_detection_group: null #"cpu"
 
-  - name: "measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean"
-    jsonpath: "$.measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean"
-    description: "Mean Tekton Pipelines controller workqueue depth"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"cpu"
-
-  # etcdMvccDb Metrics
+  # etcd metrics
   - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
     jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
     description: "Mean etcd database total size"
@@ -403,90 +485,27 @@ fields:
     metrics: true
     change_detection_group: null #"etcdMvccDb"
 
-  # memory Metrics
-  - name: "measurements_apiserver_memory_mean"
-    jsonpath: "$.measurements.apiserver.memory.mean"
-    description: "Mean memory usage for API server"
+  # Controller workqueue & latency
+  - name: "measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean"
+    description: "Mean Tekton Pipelines controller workqueue depth"
     filtering: false
     metrics: true
-    change_detection_group: null #"memory"
+    change_detection_group: null #"cpu"
 
-  - name: "measurements_apiserver_memory_max"
-    jsonpath: "$.measurements.apiserver.memory.max"
-    description: "Max memory usage for API server"
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_mean"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.mean"
+    description: "Mean Tekton Pipelines controller HTTP client latency"
     filtering: false
     metrics: true
-    change_detection_group: null #"memory"
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
 
-  - name: "measurements_kubeApiserver_memory_mean"
-    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
-    description: "Mean memory usage for kube-apiserver"
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_max"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.max"
+    description: "Maximum Tekton Pipelines controller HTTP client latency"
     filtering: false
     metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_kubeApiserver_memory_max"
-    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
-    description: "Max memory usage for kube-apiserver"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_tektonPipelinesWebhook_memory_mean"
-    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.mean"
-    description: "Mean memory usage for tekton-pipelines-webhook"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_tektonPipelinesWebhook_memory_max"
-    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.max"
-    description: "Maximum memory usage for tekton-pipelines-webhook"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_tektonPipelinesController_memory_mean"
-    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.mean"
-    description: "Mean memory usage for tekton-pipelines-controller"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_tektonPipelinesController_memory_max"
-    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.max"
-    description: "Maximum memory usage for tekton-pipelines-controller"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_tektonOperatorProxyWebhook_memory_mean"
-    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.mean"
-    description: "Mean memory usage for tekton-operator-proxy-webhook"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_tektonOperatorProxyWebhook_memory_max"
-    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.max"
-    description: "Maximum memory usage for tekton-operator-proxy-webhook"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_clusterMemoryUsageRssTotal_mean"
-    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
-    description: "Mean total RSS memory usage across all cluster nodes"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
-
-  - name: "measurements_clusterMemoryUsageRssTotal_max"
-    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
-    description: "Maximum total RSS memory usage across all cluster nodes"
-    filtering: false
-    metrics: true
-    change_detection_group: null #"memory"
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
 
   # PipelineRuns and TaskRuns counts
   - name: "results_PipelineRuns_count_succeeded"
@@ -562,28 +581,14 @@ fields:
 
   - name: "results_PipelineRuns_Success_pending_avg"
     jsonpath: "$.results.PipelineRuns.Success.pending.avg"
-    description: "Average duration for successful PipelineRuns"
+    description: "Average duration for pending PipelineRuns"
     filtering: false
     metrics: true
     change_detection_group: "PipelineRuns_TaskRuns_duration"
 
   - name: "results_PipelineRuns_Success_running_avg"
     jsonpath: "$.results.PipelineRuns.Success.running.avg"
-    description: "Average duration for successful PipelineRuns"
-    filtering: false
-    metrics: true
-    change_detection_group: "PipelineRuns_TaskRuns_duration"
-
-  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_mean"
-    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.mean"
-    description: "Mean Tekton Pipelines controller HTTP client latency"
-    filtering: false
-    metrics: true
-    change_detection_group: "PipelineRuns_TaskRuns_duration"
-
-  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_max"
-    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.max"
-    description: "Maximum Tekton Pipelines controller HTTP client latency"
+    description: "Average duration for running PipelineRuns"
     filtering: false
     metrics: true
     change_detection_group: "PipelineRuns_TaskRuns_duration"

--- a/tools/horreum/run_horreum_integration.sh
+++ b/tools/horreum/run_horreum_integration.sh
@@ -4,16 +4,19 @@
 # Horreum API Integration Script Wrapper
 # =============================================================================
 #
-# This script provides a convenient wrapper for the horreum_api.py 
-# Python script with environment variable validation and helpful error messages.
+# This script provides a convenient wrapper for OPL's horreum_api.py
+# with environment validation and helpful error messages.
 #
 # Prerequisites:
-# - horreum_api package installed via pip
-# - horreum_fields_config.yaml configuration file present
+# - Python 3 with opl.horreum_api (OPL extras on main: extras/opl/horreum_api.py)
+# - A Horreum fields YAML (this repo: tools/horreum/horreum_pipeline_fields.yaml)
 #
-# Installation:
-# pip install git+https://github.com/redhat-performance/opl.git@horreum-api
+# TLS: Prefer REQUESTS_CA_BUNDLE to a PEM with your corporate CA.
 #
+# OPL / Horreum tooling:
+# - horreum_api.py (this wrapper): OPL extras package
+#     pip install "git+https://github.com/redhat-performance/opl.git#subdirectory=extras&egg=opl-rhcloud-perf-team-extras"
+
 # =============================================================================
 
 set -e  # Exit on any error
@@ -130,9 +133,9 @@ EOF
 
 check_command_available() {
     if ! command -v "$REQUIRED_COMMAND" &> /dev/null; then
-        error "Command '$REQUIRED_COMMAND' not found in PATH"
-        error "Please install the horreum_api package:"
-        error "  pip install git+https://github.com/redhat-performance/opl.git@horreum-api"
+        error "Command '$REQUIRED_COMMAND' not found in PATH."
+        error "Install OPL extras from main, subdirectory extras:"
+        error "  pip install \"git+https://github.com/redhat-performance/opl.git#subdirectory=extras&egg=opl-rhcloud-perf-team-extras\""
         error ""
         error "Or if already installed, ensure it's in your PATH:"
         error "  which $REQUIRED_COMMAND"
@@ -243,8 +246,8 @@ show_env_summary() {
     info "Environment Configuration Summary:"
     info "=================================="
     info "HORREUM_URL: ${HORREUM_URL}"
-    info "HORREUM_API_KEY: ${HORREUM_API_KEY:+***set***}${HORREUM_API_KEY:-not set}"
-    info "HORREUM_TOKEN: ${HORREUM_TOKEN:+***set***}${HORREUM_TOKEN:-not set}"
+    info "HORREUM_API_KEY: $([[ -n "${HORREUM_API_KEY:-}" ]] && echo "***set***" || echo "not set")"
+    info "HORREUM_TOKEN: $([[ -n "${HORREUM_TOKEN:-}" ]] && echo "***set***" || echo "not set")"
     info "HORREUM_CONFIG_FILE: ${HORREUM_CONFIG_FILE:-$CONFIG_FILE_DEFAULT}"
     info "HORREUM_SCHEMA_ID: ${HORREUM_SCHEMA_ID:-not set (will create new)}"
     info "HORREUM_TEST_ID: ${HORREUM_TEST_ID:-not set (will create new)}"
@@ -252,6 +255,7 @@ show_env_summary() {
     info "SKIP_LABELS: ${SKIP_LABELS}"
     info "CLEANUP_LABELS: ${CLEANUP_LABELS}"
     info "CLEANUP_VARIABLES: ${CLEANUP_VARIABLES}"
+    info "REQUESTS_CA_BUNDLE: ${REQUESTS_CA_BUNDLE:-not set}"
     info "=================================="
     
     if [[ "${DRY_RUN}" == "true" ]]; then

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -168,40 +168,44 @@ cat $output | jq --arg type "$type" '.results.[$type].completionTime.first = '$p
 
 ###############################################################################################
 # Signing metrics
-signing_count=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at"))] | length')
+signing_json=$(echo "$data_overall" | jq -s --arg type "$type" '
+    [.[] | select(.signed == "true" and .signed_at != null)] as $signed |
+    ($signed | length) as $count |
+    if $count > 0 then
+        ([.[] | select(.signed == "false")] | length) as $false_count |
+        ([.[] | select(.signed == "unknown" or (.signed == null))] | length) as $unsigned_count |
+        ($signed | map(.signed_at | .[0:19] + "Z") | sort) as $times |
+        ($times | first) as $first |
+        ($times | last) as $last |
+        ($first | fromdate) as $first_epoch |
+        ($last | fromdate) as $last_epoch |
+        ($last_epoch - $first_epoch) as $duration |
+        {
+            count: {
+                signed_true: $count,
+                signed_false: $false_count,
+                unsigned: $unsigned_count
+            },
+            signed_at: {
+                first: $first,
+                last: $last
+            },
+            duration: $duration,
+            throughput: (if $duration > 0 then ($count / $duration | . * 10000 | round / 10000) else null end)
+        }
+    else
+        null
+    end
+')
 
-if [ "$signing_count" -gt 0 ]; then
+if [[ "$signing_json" != "null" ]]; then
+    signing_count=$(echo "$signing_json" | jq '.count.signed_true')
     echo "DEBUG: Computing signing metrics for ${signing_count} signed ${type}..."
+    jq --argjson metrics "$signing_json" --arg type "$type" \
+        '.results.[$type].signing = $metrics' "$output" > "$$.json" && mv -f "$$.json" "$output"
 
-    # Signing count
-    signing_false=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "false")] | length')
-    signing_unknown=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "unknown" or (has("signed") | not))] | length')
-    cat $output | jq --arg type "$type" \
-        '.results.[$type].signing.count.signed_true = '$signing_count'
-        | .results.[$type].signing.count.signed_false = '$signing_false'
-        | .results.[$type].signing.count.unsigned = '$signing_unknown'' >"$$.json" && mv -f "$$.json" "$output"
-
-    # Signing timestamps: first and last signed_at
-    signing_first=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at")) | (.signed_at | .[0:19] + "Z")] | sort | first')
-    signing_last=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at")) | (.signed_at | .[0:19] + "Z")] | sort | last')
-    cat $output | jq --arg type "$type" \
-        '.results.[$type].signing.signed_at.first = '$signing_first'
-        | .results.[$type].signing.signed_at.last = '$signing_last'' >"$$.json" && mv -f "$$.json" "$output"
-
-    # Signing duration: last_signed - first_signed (pure signing window)
-    first_signed_epoch=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at")) | (.signed_at | .[0:19] + "Z" | fromdate)] | min')
-    last_signed_epoch=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at")) | (.signed_at | .[0:19] + "Z" | fromdate)] | max')
-    signing_duration=$(echo "$last_signed_epoch - $first_signed_epoch" | bc)
-    cat $output | jq --arg type "$type" \
-        '.results.[$type].signing.duration = '$signing_duration'' >"$$.json" && mv -f "$$.json" "$output"
-
-    # Signing throughput: signed_count / signing_duration (signs per second)
-    if [ "$signing_duration" != "0" ]; then
-        signing_throughput=$(echo "scale=4; $signing_count / $signing_duration" | bc)
-        cat $output | jq --arg type "$type" \
-            '.results.[$type].signing.throughput = '$signing_throughput'' >"$$.json" && mv -f "$$.json" "$output"
-    fi
-
+    signing_duration=$(echo "$signing_json" | jq '.duration')
+    signing_throughput=$(echo "$signing_json" | jq '.throughput')
     echo "DEBUG: Signing count=${signing_count}, duration=${signing_duration}s, throughput=${signing_throughput}/s"
 else
     echo "DEBUG: No signed ${type} found. Skipping signing metrics..."

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -22,7 +22,7 @@ if [ ! -f $output ]; then
 
 cat <<EOF >$output
 {
-    "name": "OpenShift Pipelines scalingPipelines test",
+    "name": "$(if [[ "${TEST_SCENARIO:-}" == *signing* ]]; then echo "OpenShift Pipelines Chains signing test"; else echo "OpenShift Pipelines scalingPipelines test"; fi)",
     "results": {
         "started": "$started",
         "ended": "$ended"
@@ -165,3 +165,44 @@ cat $output | jq --arg type "$type" '.results.[$type].startTime.first = '$pr_sta
 pr_completionTime_first=$(echo $data | jq  '[.[] | select(has("finished_at")) | (.completionTime // (.finished_at | .[0:19] + "Z") ) ] | sort | first')
 pr_completionTime_last=$(echo $data | jq  '[.[] | select(has("finished_at")) | (.completionTime // (.finished_at | .[0:19] + "Z") ) ] | sort | last')
 cat $output | jq --arg type "$type" '.results.[$type].completionTime.first = '$pr_completionTime_first' | .results.[$type].completionTime.last = '$pr_completionTime_last'' >"$$.json" && mv -f "$$.json" "$output"
+
+###############################################################################################
+# Signing metrics
+signing_count=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at"))] | length')
+
+if [ "$signing_count" -gt 0 ]; then
+    echo "DEBUG: Computing signing metrics for ${signing_count} signed ${type}..."
+
+    # Signing count
+    signing_false=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "false")] | length')
+    signing_unknown=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "unknown" or (has("signed") | not))] | length')
+    cat $output | jq --arg type "$type" \
+        '.results.[$type].signing.count.signed_true = '$signing_count'
+        | .results.[$type].signing.count.signed_false = '$signing_false'
+        | .results.[$type].signing.count.unsigned = '$signing_unknown'' >"$$.json" && mv -f "$$.json" "$output"
+
+    # Signing timestamps: first and last signed_at
+    signing_first=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at")) | (.signed_at | .[0:19] + "Z")] | sort | first')
+    signing_last=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at")) | (.signed_at | .[0:19] + "Z")] | sort | last')
+    cat $output | jq --arg type "$type" \
+        '.results.[$type].signing.signed_at.first = '$signing_first'
+        | .results.[$type].signing.signed_at.last = '$signing_last'' >"$$.json" && mv -f "$$.json" "$output"
+
+    # Signing duration: last_signed - first_signed (pure signing window)
+    first_signed_epoch=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at")) | (.signed_at | .[0:19] + "Z" | fromdate)] | min')
+    last_signed_epoch=$(echo "$data_overall" | jq -s '[.[] | select(.signed == "true" and has("signed_at")) | (.signed_at | .[0:19] + "Z" | fromdate)] | max')
+    signing_duration=$(echo "$last_signed_epoch - $first_signed_epoch" | bc)
+    cat $output | jq --arg type "$type" \
+        '.results.[$type].signing.duration = '$signing_duration'' >"$$.json" && mv -f "$$.json" "$output"
+
+    # Signing throughput: signed_count / signing_duration (signs per second)
+    if [ "$signing_duration" != "0" ]; then
+        signing_throughput=$(echo "scale=4; $signing_count / $signing_duration" | bc)
+        cat $output | jq --arg type "$type" \
+            '.results.[$type].signing.throughput = '$signing_throughput'' >"$$.json" && mv -f "$$.json" "$output"
+    fi
+
+    echo "DEBUG: Signing count=${signing_count}, duration=${signing_duration}s, throughput=${signing_throughput}/s"
+else
+    echo "DEBUG: No signed ${type} found. Skipping signing metrics..."
+fi


### PR DESCRIPTION
## Summary

Adds Chains signing performance test support with signing metrics computation, Horreum test configuration, and reorganizes horreum tooling.

### Chains signing metrics (`tools/stats.sh`)
- Compute signing counts: `signed_true`, `signed_false`, `unsigned` per PipelineRun and TaskRun
- Compute signing timestamps: first/last `signed_at`
- Compute signing duration (last signed - first signed) and throughput (signs/second)
- Dynamically set test name to "Chains signing test" or "scalingPipelines test" based on `TEST_SCENARIO`

### Chains CI support (`ci-scripts/lib.sh`)
- `capture_ha_qbt_config` falls back to Chains-specific env vars (`DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS`, `DEPLOYMENT_CHAINS_KUBE_API_QPS`, etc.)
- `capture_scenario_name` generates signing-aware descriptive names when `TEST_SCENARIO` contains "signing"

### Horreum integration
- New `horreum_chains_fields.yaml` defining 65 fields for the Chains test — signing metrics, chains controller CPU/memory/workqueue, shared infrastructure and restart labels
- 10 change detection groups: `chains_cpu`, `chains_memory`, `chains_workqueue`, `signing_count`, `signing_unsigned_count`, `signing_throughput`, shared `restarts` and count groups
- Shares schema with Pipelines test (`CLEANUP_LABELS=false` preserves shared labels)
- Reorganized `horreum_pipeline_fields.yaml` to group metrics by component (CPU + memory together) for consistency with Chains YAML
- Moved horreum tooling into `tools/horreum/` with README documenting the workflow