### PR TITLE
Add Results watcher ingestion latency and Locust API summary metrics

### DIFF
--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -171,10 +171,55 @@ if [ "$INSTALL_RESULTS" == "true" ]; then
 
     # Parse and store JSON log lines 
     echo "[" > "$results_api_json"
-    grep -oP '\{.*?\}' "$results_api_logs" \
+    grep -oE '\{[^}]+\}' "$results_api_logs" \
         | jq -e -c "$JQ_FIELDS_TO_EXTRACT" 2>"$results_api_error_logs" \
         | sed '$!s/$/,/' >> "$results_api_json"
     echo "]" >> "$results_api_json"
+
+    info "Parsing Locust summary stats"
+    locust_log="$ARTIFACT_DIR/locust-test.log"
+    if [ -f "$locust_log" ]; then
+        locust_summary=$(python3 -c "
+import json, re, sys
+
+with open('$locust_log') as f:
+    content = f.read()
+
+# Final summary is printed after 'Shutting down' for each scenario
+shutdown_blocks = content.split('Shutting down (exit code 0)')
+
+results = {}
+for block in shutdown_blocks[1:]:
+    lines = block.strip().split('\n')
+    for line in lines:
+        match = re.match(
+            r'\s*GET\s+(\S+)\s+(\d+)\s+(\d+)\([\d.]+%\)\s+\|\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+\|\s+([\d.]+)\s+([\d.]+)',
+            line
+        )
+        if match and match.group(1) != 'fetch_id':
+            name = match.group(1)
+            results[name] = {
+                'count': int(match.group(2)),
+                'failures': int(match.group(3)),
+                'latency_ms': {
+                    'min': int(match.group(5)),
+                    'avg': int(match.group(4)),
+                    'max': int(match.group(6)),
+                },
+                'rps': float(match.group(8))
+            }
+            break
+
+if results:
+    print(json.dumps(results))
+")
+
+        if [ -n "$locust_summary" ]; then
+            jq --argjson locust "$locust_summary" '.results.ResultsAPI = $locust' "$monitoring_collection_data" > "${monitoring_collection_data}.tmp" && mv "${monitoring_collection_data}.tmp" "$monitoring_collection_data"
+        fi
+    else
+        warning "Locust log file not found, skipping Locust summary"
+    fi
 else
     info "Skipping Results-API log data"
 fi

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -210,3 +210,56 @@ if [[ "$signing_json" != "null" ]]; then
 else
     echo "DEBUG: No signed ${type} found. Skipping signing metrics..."
 fi
+
+###############################################################################################
+# Results ingestion metrics
+ingestion_json=$(echo "$data_overall" | jq -s --arg type "$type" '
+    [.[] | select(.result_at != null and .completionTime != null)] as $ingested |
+    ($ingested | length) as $count |
+    if $count > 0 then
+        ($ingested | map(
+            ((.result_at | .[0:19] + "Z" | fromdate) - (.completionTime | fromdate))
+        )) as $latencies |
+        ($ingested | map(.result_at | .[0:19] + "Z") | sort) as $times |
+        ($times | first) as $first |
+        ($times | last) as $last |
+        ($first | fromdate) as $first_epoch |
+        ($last | fromdate) as $last_epoch |
+        ($last_epoch - $first_epoch) as $duration |
+        ([.[] | select(.result_stored == "true")] | length) as $stored_count |
+        ([.[] | select(.result_stored == "false")] | length) as $not_stored_count |
+        {
+            count: {
+                ingested: $count,
+                stored_true: $stored_count,
+                stored_false: $not_stored_count
+            },
+            latency: {
+                min: ($latencies | min),
+                avg: (($latencies | add / length) * 10000 | round / 10000),
+                max: ($latencies | max)
+            },
+            result_at: {
+                first: $first,
+                last: $last
+            },
+            duration: $duration,
+            throughput: (if $duration > 0 then ($count / $duration | . * 10000 | round / 10000) else null end)
+        }
+    else
+        null
+    end
+')
+
+if [[ "$ingestion_json" != "null" ]]; then
+    ingestion_count=$(echo "$ingestion_json" | jq '.count.ingested')
+    echo "DEBUG: Computing ingestion metrics for ${ingestion_count} ingested ${type}..."
+    jq --argjson metrics "$ingestion_json" --arg type "$type" \
+        '.results.[$type].results_ingestion = $metrics' "$output" > "$$.json" && mv -f "$$.json" "$output"
+
+    ingestion_latency_avg=$(echo "$ingestion_json" | jq '.latency.avg')
+    ingestion_throughput=$(echo "$ingestion_json" | jq '.throughput')
+    echo "DEBUG: Ingestion count=${ingestion_count}, avg_latency=${ingestion_latency_avg}s, throughput=${ingestion_throughput}/s"
+else
+    echo "DEBUG: No ingested ${type} found. Skipping ingestion metrics..."
+fi


### PR DESCRIPTION
## Summary

- Add Results Watcher ingestion latency metrics (min/avg/max, throughput)
- Parse Locust final summary from `locust-test.log` into `benchmark-tekton.json` for per-endpoint API stats (`/record`, `/records`)
- Fix `grep -oP` to `grep -oE` in `collect-results.sh` for macOS compatibility

## Sample Output
New fields added to `benchmark-tekton.json`:
```json
{
  "results.PipelineRuns.results_ingestion": {
    "count": { "ingested": 100, "stored_true": 100, "stored_false": 0 },
    "latency": { "min": 0, "avg": 0.42, "max": 2 },
    "result_at": { "first": "2026-06-15T15:09:18Z", "last": "2026-06-15T15:24:28Z" },
    "duration": 910,
    "throughput": 0.1099
  },
  "results.TaskRuns.results_ingestion": {
    "count": { "ingested": 500, "stored_true": 500, "stored_false": 0 },
    "latency": { "min": 0, "avg": 0.46, "max": 8 },
    "result_at": { "first": "2026-06-15T15:09:11Z", "last": "2026-06-15T15:24:29Z" },
    "duration": 918,
    "throughput": 0.5447
  },
  "results.ResultsAPI": {
    "/record": {
      "count": 1317631, "failures": 0,
      "latency_ms": { "min": 2, "avg": 65, "max": 559 },
      "rps": 1463.88
    },
    "/records": {
      "count": 95063, "failures": 0,
      "latency_ms": { "min": 48, "avg": 940, "max": 1910 },
      "rps": 105.62
    }
  }
}
```