### PR TITLE
feat: collect Tekton Results Watcher logs in CI artifacts

### DIFF
--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -59,15 +59,15 @@ deactivate
 set -u
 
 # track monitoring start time
-mstart=$(date_utc_iso8601_seconds)
+mstart=$(date --utc --iso-8601=seconds)
 
 info "Collecting monitoring data..."
 if [ -f "$monitoring_collection_data" ]; then
     set +u
     source venv/bin/activate
     set -u
-    mstart=$(date_utc_parse_iso8601_seconds "$(status_data.py --status-data-file "$monitoring_collection_data" --get results.started)")
-    mend=$(date_utc_parse_iso8601_seconds "$(status_data.py --status-data-file "$monitoring_collection_data" --get results.ended)")
+    mstart=$(date --utc --date "$(status_data.py --status-data-file "$monitoring_collection_data" --get results.started)" --iso-8601=seconds)
+    mend=$(date --utc --date "$(status_data.py --status-data-file "$monitoring_collection_data" --get results.ended)" --iso-8601=seconds)
     mhost=$(kubectl -n openshift-monitoring get route -l app.kubernetes.io/name=thanos-query -o json | jq --raw-output '.items[0].spec.host')
     status_data.py \
         --status-data-file "$monitoring_collection_data" \

--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -12,6 +12,7 @@ monitoring_collection_log=$ARTIFACT_DIR/monitoring-collection.log
 monitoring_collection_dir=$ARTIFACT_DIR/monitoring-collection-raw-data-dir
 tekton_pipelines_controller_log=$ARTIFACT_DIR/tekton-pipelines-controller.log
 tekton_chains_controller_log=$ARTIFACT_DIR/tekton-chains-controller.log
+tekton_results_watcher_log=$ARTIFACT_DIR/tekton-results-watcher.log
 creationtimestamp_collection_log=$ARTIFACT_DIR/creationtimestamp-collection.log
 results_api_logs="$ARTIFACT_DIR/results-api-logs.txt"
 results_api_json="$ARTIFACT_DIR/results-api-logs.json"
@@ -39,6 +40,11 @@ mkdir -p "${monitoring_collection_dir}"
 info "Collecting logs..."
 oc -n openshift-pipelines logs --tail=-1 --all-containers=true --max-log-requests=10 -l app.kubernetes.io/name=controller,app.kubernetes.io/part-of=tekton-pipelines,app=tekton-pipelines-controller >"$tekton_pipelines_controller_log" || true
 oc -n openshift-pipelines logs --tail=-1 --all-containers=true --max-log-requests=10 -l app.kubernetes.io/name=controller,app.kubernetes.io/part-of=tekton-chains,app=tekton-chains-controller >"$tekton_chains_controller_log" || true
+
+if [ "$INSTALL_RESULTS" == "true" ]; then
+    info "Collecting Tekton Results Watcher logs..."
+    oc -n openshift-pipelines logs --tail=-1 --all-containers=true --max-log-requests=10 -l app.kubernetes.io/name=tekton-results-watcher >"$tekton_results_watcher_log" || true
+fi
 
 info "Setting up tool to collect monitoring data..."
 python3 -m venv venv

--- a/ci-scripts/collect-results.sh
+++ b/ci-scripts/collect-results.sh
@@ -44,6 +44,7 @@ oc -n openshift-pipelines logs --tail=-1 --all-containers=true --max-log-request
 if [ "$INSTALL_RESULTS" == "true" ]; then
     info "Collecting Tekton Results Watcher logs..."
     oc -n openshift-pipelines logs --tail=-1 --all-containers=true --max-log-requests=10 -l app.kubernetes.io/name=tekton-results-watcher >"$tekton_results_watcher_log" || true
+    oc -n tekton-pipelines logs --tail=-1 --all-containers=true --max-log-requests=10 -l app.kubernetes.io/name=tekton-results-watcher >>"$tekton_results_watcher_log" || true
 fi
 
 info "Setting up tool to collect monitoring data..."
@@ -58,15 +59,15 @@ deactivate
 set -u
 
 # track monitoring start time
-mstart=$(date --utc  --iso-8601=seconds)
+mstart=$(date_utc_iso8601_seconds)
 
 info "Collecting monitoring data..."
 if [ -f "$monitoring_collection_data" ]; then
     set +u
     source venv/bin/activate
     set -u
-    mstart=$(date --utc --date "$(status_data.py --status-data-file "$monitoring_collection_data" --get results.started)" --iso-8601=seconds)
-    mend=$(date --utc --date "$(status_data.py --status-data-file "$monitoring_collection_data" --get results.ended)" --iso-8601=seconds)
+    mstart=$(date_utc_parse_iso8601_seconds "$(status_data.py --status-data-file "$monitoring_collection_data" --get results.started)")
+    mend=$(date_utc_parse_iso8601_seconds "$(status_data.py --status-data-file "$monitoring_collection_data" --get results.ended)")
     mhost=$(kubectl -n openshift-monitoring get route -l app.kubernetes.io/name=thanos-query -o json | jq --raw-output '.items[0].spec.host')
     status_data.py \
         --status-data-file "$monitoring_collection_data" \


### PR DESCRIPTION
When INSTALL_RESULTS=true, the CI was missing critical diagnostic information from the Results Watcher controller. This change adds collection of Watcher logs to the artifacts alongside existing controller logs.

The Watcher logs contain:
- PipelineRun/TaskRun watch events
- Results API storage operations
- Performance metrics (QPS, burst, threadiness)
- Error conditions and retry logic

This will help debug Results performance issues, incomplete run storage, and API communication problems.