### PR TITLE
Add scenario-specific Horreum configs and route uploads by test name

### DIFF
--- a/ci-scripts/prow-to-storage.sh
+++ b/ci-scripts/prow-to-storage.sh
@@ -71,16 +71,6 @@ for prow_run in "${PROW_JOBS[@]}"; do
             json_complete "$out" || continue
             # shellcheck disable=SC2016  # $schema is a jq field name, not a shell variable
             enritch_stuff "$out" '."$schema"' "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
-
-            case "$prow_run" in
-                *-ha-10-qbt*)   test_name="Scaling Pipelines test-ha_qbt" ;;
-                *-ha-10-state*) test_name="Scaling Pipelines test-ha_statefulsets" ;;
-                *-ha-10*)       test_name="Scaling Pipelines test-ha_deployement" ;;
-                *-qbt*)         test_name="Scaling Pipelines test-qbt_deployement" ;;
-                *)             test_name="Scaling Pipelines test-standard" ;;
-            esac
-
-            enritch_stuff "$out" '.name' "$test_name"
             horreum_upload "$out" "metadata.env.SUBJOB_BUILD_ID" "__metadata_env_SUBJOB_BUILD_ID" "Openshift-pipelines-team" "PUBLIC" || ((errors_count+=1))
             resultsdashboard_upload "$out" "Developer" "OpenShift Pipelines" "$( date --utc -Idate )" "@metadata.env.SUBJOB_BUILD_ID" || ((errors_count+=1))
         done

--- a/ci-scripts/prow-to-storage.sh
+++ b/ci-scripts/prow-to-storage.sh
@@ -71,6 +71,16 @@ for prow_run in "${PROW_JOBS[@]}"; do
             json_complete "$out" || continue
             # shellcheck disable=SC2016  # $schema is a jq field name, not a shell variable
             enritch_stuff "$out" '."$schema"' "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+
+            case "$prow_run" in
+                *-ha-10-qbt*)   test_name="Scaling Pipelines test-ha_qbt" ;;
+                *-ha-10-state*) test_name="Scaling Pipelines test-ha_statefulsets" ;;
+                *-ha-10*)       test_name="Scaling Pipelines test-ha_deployement" ;;
+                *-qbt*)         test_name="Scaling Pipelines test-qbt_deployement" ;;
+                *)             test_name="Scaling Pipelines test-standard" ;;
+            esac
+
+            enritch_stuff "$out" '.name' "$test_name"
             horreum_upload "$out" "metadata.env.SUBJOB_BUILD_ID" "__metadata_env_SUBJOB_BUILD_ID" "Openshift-pipelines-team" "PUBLIC" || ((errors_count+=1))
             resultsdashboard_upload "$out" "Developer" "OpenShift Pipelines" "$( date --utc -Idate )" "@metadata.env.SUBJOB_BUILD_ID" || ((errors_count+=1))
         done

--- a/tools/horreum/README.md
+++ b/tools/horreum/README.md
@@ -7,7 +7,7 @@ This directory (`tools/horreum/`) contains configuration and tooling for managin
 | File | Purpose |
 |---|---|
 | `run_horreum_integration.sh` | Wrapper script that invokes `horreum_api.py` with env validation and defaults |
-| `horreum_pipeline_fields.yaml` | Horreum config for the **Pipelines** test (`OpenShift Pipelines scalingPipelines test`) |
+| `horreum_pipeline/` | Five scenario-specific Horreum configs under `tools/horreum/horreum_pipeline/` |
 | `horreum_chains_fields.yaml` | Horreum config for the **Chains** test (`OpenShift Pipelines Chains signing test`) |
 
 ## Architecture
@@ -147,8 +147,22 @@ Chains omits `parameters_test_concurrent` (always 20) and `deployment_haConfig_c
 
 The `name` field in `benchmark-tekton.json` determines which Horreum test receives the data:
 
-- `stats.sh` sets the name based on `TEST_SCENARIO`:
+- `stats.sh` sets the name from deployment env vars (HA / QBT / controller type):
   - `*signing*` → `"OpenShift Pipelines Chains signing test"`
-  - Otherwise → `"OpenShift Pipelines scalingPipelines test"`
-- `prow-to-storage.sh` uploads the JSON to Horreum, which routes it by matching `@name`
-- The Horreum test name in the YAML must match exactly
+  - standard → `"Scaling Pipelines test-standard"`
+  - QBT only → `"Scaling Pipelines test-qbt_deployement"`
+  - HA deployments → `"Scaling Pipelines test-ha_deployement"`
+  - HA statefulSets → `"Scaling Pipelines test-ha_statefulsets"`
+  - HA + QBT → `"Scaling Pipelines test-ha_qbt"`
+- `prow-to-storage.sh` patches `.name` from the Prow job suffix before upload
+- The Horreum `test.name` in each scenario YAML must match exactly
+
+Scenario YAML files:
+
+| File | Horreum test name |
+|---|---|
+| `horreum_pipeline_standard.yaml` | `Scaling Pipelines test-standard` |
+| `horreum_pipeline_qbt_deployement.yaml` | `Scaling Pipelines test-qbt_deployement` |
+| `horreum_pipeline_ha_deployement.yaml` | `Scaling Pipelines test-ha_deployement` |
+| `horreum_pipeline_ha_statefulsets.yaml` | `Scaling Pipelines test-ha_statefulsets` |
+| `horreum_pipeline_ha_qbt.yaml` | `Scaling Pipelines test-ha_qbt` |

--- a/tools/horreum/horreum_pipeline/horreum_pipeline_ha_deployement.yaml
+++ b/tools/horreum/horreum_pipeline/horreum_pipeline_ha_deployement.yaml
@@ -1,0 +1,759 @@
+# Horreum Fields Configuration
+# This file defines the fields to extract from performance data, their change detection settings,
+# and grouping information for comprehensive monitoring
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"  # Options: relativeDifference, fixedThreshold, hunter
+  window: 10                   # Number of data points to analyze
+  min_previous: 5              # Minimum previous data points required
+  threshold: 0.10              # Default 10% change threshold
+
+# Change detection groups with specific configurations
+change_detection_groups:
+  "cpu":
+    description: "CPU metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+    model: "relativeDifference"
+
+  "etcdMvccDb":
+    description: "etcd database metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "memory":
+    description: "memory metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 990
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3960
+      min_inclusive: true
+      max_enabled: false
+
+  "PipelineRuns_TaskRuns_duration":
+    description: "PLRs/TRs duration metrics"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "TaskRunsToPods_creation":
+    description: "TaskRun-to-Pods creation lag"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "controller_cpu":
+    description: "Controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.99154
+      max_inclusive: true
+      min_enabled: false
+  
+  "controller_memory":
+    description: "Controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 6734249574
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_cpu":
+    description: "Webhook CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.31778
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_memory":
+    description: "Webhook memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 315097088
+      max_inclusive: true
+      min_enabled: false
+
+  "workqueue_depth":
+    description: "Workqueue depth metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 505.316
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 924009062
+      max_inclusive: true
+      min_enabled: false
+  
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0088301
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 19.817
+      max_inclusive: true
+      min_enabled: false
+# Test definition
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Scaling Pipelines test-ha_deployement"
+  folder: "Openshift-pipelines"
+  description: "Results of this Prow job: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly/"
+  datastoreId: 1  # Assuming default datastore
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_concurrent
+    - parameters_test_total
+    - deployment_haConfig_controllerType
+    - deployment_qbtConfig_qbtEnabled
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  # JSON schema metadata
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. math)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightlyBuild_pipelinesControllerGitCommit"
+    jsonpath: "$.deployment.nightly_build.pipelines_controller_git_commit"
+    description: "Upstream tektoncd/pipeline git SHA (controller image upstream-vcs-ref)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for pipelines controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # tekton-pipelines-controller
+  - name: "measurements_tektonPipelinesController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesController_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-pipelines-webhook
+  - name: "measurements_tektonPipelinesWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-operator-proxy-webhook
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate" #"cpu"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size" #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration" #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  # Controller workqueue & latency
+  - name: "measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean"
+    description: "Mean Tekton Pipelines controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "workqueue_depth" #"cpu"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_mean"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.mean"
+    description: "Mean Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_max"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.max"
+    description: "Maximum Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  # PipelineRuns_TaskRuns_duration
+  - name: "results_PipelineRuns_duration_avg"
+    jsonpath: "$.results.PipelineRuns.duration.avg"
+    description: "Average duration for PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_duration_avg"
+    jsonpath: "$.results.TaskRuns.duration.avg"
+    description: "Average duration for TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_pending_avg"
+    jsonpath: "$.results.TaskRuns.Success.pending.avg"
+    description: "Average pending time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_running_avg"
+    jsonpath: "$.results.TaskRuns.Success.running.avg"
+    description: "Average running time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_duration_avg"
+    jsonpath: "$.results.TaskRuns.Success.duration.avg"
+    description: "Average duration for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_duration_avg"
+    jsonpath: "$.results.PipelineRuns.Success.duration.avg"
+    description: "Average duration for successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_pending_avg"
+    jsonpath: "$.results.PipelineRuns.Success.pending.avg"
+    description: "Average duration for pending PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_running_avg"
+    jsonpath: "$.results.PipelineRuns.Success.running.avg"
+    description: "Average duration for running PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # TaskRunsToPods_creation
+  - name: "results_TaskRunsToPods_creationTimestampDiff_mean"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.mean"
+    description: "Mean time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  - name: "results_TaskRunsToPods_creationTimestampDiff_max"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.max"
+    description: "Maximum time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeController_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-controller\".restarts.range"
+    description: "pipelinesAsCodeController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeWatcher_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-watcher\".restarts.range"
+    description: "pipelinesAsCodeWatcher restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonEventsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-events-controller\".restarts.range"
+    description: "tektonEventsController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesRemoteResolvers_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-remote-resolvers\".restarts.range"
+    description: "tektonPipelinesRemoteResolvers restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-controller\".restarts.range"
+    description: "tektonTriggersController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersCoreInterceptors_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-core-interceptors\".restarts.range"
+    description: "tektonTriggersCoreInterceptors restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-webhook\".restarts.range"
+    description: "tektonTriggersWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tknCliServe_restarts_range"
+    jsonpath: "$.measurements.\"tkn-cli-serve\".restarts.range"
+    description: "tkn-cli-serve restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null

--- a/tools/horreum/horreum_pipeline/horreum_pipeline_ha_qbt.yaml
+++ b/tools/horreum/horreum_pipeline/horreum_pipeline_ha_qbt.yaml
@@ -1,0 +1,759 @@
+# Horreum Fields Configuration
+# This file defines the fields to extract from performance data, their change detection settings,
+# and grouping information for comprehensive monitoring
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"  # Options: relativeDifference, fixedThreshold, hunter
+  window: 10                   # Number of data points to analyze
+  min_previous: 5              # Minimum previous data points required
+  threshold: 0.10              # Default 10% change threshold
+
+# Change detection groups with specific configurations
+change_detection_groups:
+  "cpu":
+    description: "CPU metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+    model: "relativeDifference"
+
+  "etcdMvccDb":
+    description: "etcd database metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "memory":
+    description: "memory metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 820
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3280
+      min_inclusive: true
+      max_enabled: false
+
+  "PipelineRuns_TaskRuns_duration":
+    description: "PLRs/TRs duration metrics"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "TaskRunsToPods_creation":
+    description: "TaskRun-to-Pods creation lag"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "controller_cpu":
+    description: "Controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 1.16373
+      max_inclusive: true
+      min_enabled: false
+  
+  "controller_memory":
+    description: "Controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 7057590886
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_cpu":
+    description: "Webhook CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.35137
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_memory":
+    description: "Webhook memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 366267597
+      max_inclusive: true
+      min_enabled: false
+
+  "workqueue_depth":
+    description: "Workqueue depth metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 32.009
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 1026209587
+      max_inclusive: true
+      min_enabled: false
+  
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0121556
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 21.077
+      max_inclusive: true
+      min_enabled: false
+# Test definition
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Scaling Pipelines test-ha_qbt"
+  folder: "Openshift-pipelines"
+  description: "Results of this Prow job: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly/"
+  datastoreId: 1  # Assuming default datastore
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_concurrent
+    - parameters_test_total
+    - deployment_haConfig_controllerType
+    - deployment_qbtConfig_qbtEnabled
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  # JSON schema metadata
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. math)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightlyBuild_pipelinesControllerGitCommit"
+    jsonpath: "$.deployment.nightly_build.pipelines_controller_git_commit"
+    description: "Upstream tektoncd/pipeline git SHA (controller image upstream-vcs-ref)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for pipelines controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # tekton-pipelines-controller
+  - name: "measurements_tektonPipelinesController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesController_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-pipelines-webhook
+  - name: "measurements_tektonPipelinesWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-operator-proxy-webhook
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate" #"cpu"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size" #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration" #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  # Controller workqueue & latency
+  - name: "measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean"
+    description: "Mean Tekton Pipelines controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "workqueue_depth" #"cpu"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_mean"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.mean"
+    description: "Mean Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_max"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.max"
+    description: "Maximum Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  # PipelineRuns_TaskRuns_duration
+  - name: "results_PipelineRuns_duration_avg"
+    jsonpath: "$.results.PipelineRuns.duration.avg"
+    description: "Average duration for PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_duration_avg"
+    jsonpath: "$.results.TaskRuns.duration.avg"
+    description: "Average duration for TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_pending_avg"
+    jsonpath: "$.results.TaskRuns.Success.pending.avg"
+    description: "Average pending time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_running_avg"
+    jsonpath: "$.results.TaskRuns.Success.running.avg"
+    description: "Average running time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_duration_avg"
+    jsonpath: "$.results.TaskRuns.Success.duration.avg"
+    description: "Average duration for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_duration_avg"
+    jsonpath: "$.results.PipelineRuns.Success.duration.avg"
+    description: "Average duration for successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_pending_avg"
+    jsonpath: "$.results.PipelineRuns.Success.pending.avg"
+    description: "Average duration for pending PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_running_avg"
+    jsonpath: "$.results.PipelineRuns.Success.running.avg"
+    description: "Average duration for running PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # TaskRunsToPods_creation
+  - name: "results_TaskRunsToPods_creationTimestampDiff_mean"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.mean"
+    description: "Mean time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  - name: "results_TaskRunsToPods_creationTimestampDiff_max"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.max"
+    description: "Maximum time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeController_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-controller\".restarts.range"
+    description: "pipelinesAsCodeController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeWatcher_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-watcher\".restarts.range"
+    description: "pipelinesAsCodeWatcher restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonEventsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-events-controller\".restarts.range"
+    description: "tektonEventsController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesRemoteResolvers_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-remote-resolvers\".restarts.range"
+    description: "tektonPipelinesRemoteResolvers restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-controller\".restarts.range"
+    description: "tektonTriggersController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersCoreInterceptors_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-core-interceptors\".restarts.range"
+    description: "tektonTriggersCoreInterceptors restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-webhook\".restarts.range"
+    description: "tektonTriggersWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tknCliServe_restarts_range"
+    jsonpath: "$.measurements.\"tkn-cli-serve\".restarts.range"
+    description: "tkn-cli-serve restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null

--- a/tools/horreum/horreum_pipeline/horreum_pipeline_ha_statefulsets.yaml
+++ b/tools/horreum/horreum_pipeline/horreum_pipeline_ha_statefulsets.yaml
@@ -3,11 +3,6 @@
 # and grouping information for comprehensive monitoring
 
 
-#ha_deployement
-#ha_statefulsets
-#qbt_enabled=>qbt
-#ha_abt
-#standard=>noha_nonqbt
 # Global configuration
 global:
   owner: "Openshift-pipelines-team"

--- a/tools/horreum/horreum_pipeline/horreum_pipeline_ha_statefulsets.yaml
+++ b/tools/horreum/horreum_pipeline/horreum_pipeline_ha_statefulsets.yaml
@@ -1,0 +1,766 @@
+# Horreum Fields Configuration
+# This file defines the fields to extract from performance data, their change detection settings,
+# and grouping information for comprehensive monitoring
+
+
+#ha_deployement
+#ha_statefulsets
+#qbt_enabled=>qbt
+#ha_abt
+#standard=>noha_nonqbt
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"  # Options: relativeDifference, fixedThreshold, hunter
+  window: 10                   # Number of data points to analyze
+  min_previous: 5              # Minimum previous data points required
+  threshold: 0.10              # Default 10% change threshold
+
+# Change detection groups with specific configurations
+change_detection_groups:
+  "cpu":
+    description: "CPU metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+    model: "relativeDifference"
+
+  "etcdMvccDb":
+    description: "etcd database metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "memory":
+    description: "memory metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 990
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3960
+      min_inclusive: true
+      max_enabled: false
+
+  "PipelineRuns_TaskRuns_duration":
+    description: "PLRs/TRs duration metrics"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "TaskRunsToPods_creation":
+    description: "TaskRun-to-Pods creation lag"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "controller_cpu":
+    description: "Controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 1.11088
+      max_inclusive: true
+      min_enabled: false
+  
+  "controller_memory":
+    description: "Controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 6938436403
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_cpu":
+    description: "Webhook CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.33219
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_memory":
+    description: "Webhook memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 340367770
+      max_inclusive: true
+      min_enabled: false
+
+  "workqueue_depth":
+    description: "Workqueue depth metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 505
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 1025507328
+      max_inclusive: true
+      min_enabled: false
+  
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0090585
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 21.484
+      max_inclusive: true
+      min_enabled: false
+# Test definition
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Scaling Pipelines test-ha_statefulsets"
+  folder: "Openshift-pipelines"
+  description: "Results of this Prow job: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly/"
+  datastoreId: 1  # Assuming default datastore
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_concurrent
+    - parameters_test_total
+    - deployment_haConfig_controllerType
+    - deployment_qbtConfig_qbtEnabled
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  # JSON schema metadata
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. math)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightlyBuild_pipelinesControllerGitCommit"
+    jsonpath: "$.deployment.nightly_build.pipelines_controller_git_commit"
+    description: "Upstream tektoncd/pipeline git SHA (controller image upstream-vcs-ref)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for pipelines controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # tekton-pipelines-controller
+  - name: "measurements_tektonPipelinesController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesController_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-pipelines-webhook
+  - name: "measurements_tektonPipelinesWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-operator-proxy-webhook
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate" #"cpu"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size" #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration" #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  # Controller workqueue & latency
+  - name: "measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean"
+    description: "Mean Tekton Pipelines controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "workqueue_depth" #"cpu"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_mean"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.mean"
+    description: "Mean Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_max"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.max"
+    description: "Maximum Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+
+  # PipelineRuns_TaskRuns_duration
+  - name: "results_PipelineRuns_duration_avg"
+    jsonpath: "$.results.PipelineRuns.duration.avg"
+    description: "Average duration for PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_duration_avg"
+    jsonpath: "$.results.TaskRuns.duration.avg"
+    description: "Average duration for TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_pending_avg"
+    jsonpath: "$.results.TaskRuns.Success.pending.avg"
+    description: "Average pending time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_running_avg"
+    jsonpath: "$.results.TaskRuns.Success.running.avg"
+    description: "Average running time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_duration_avg"
+    jsonpath: "$.results.TaskRuns.Success.duration.avg"
+    description: "Average duration for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_duration_avg"
+    jsonpath: "$.results.PipelineRuns.Success.duration.avg"
+    description: "Average duration for successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_pending_avg"
+    jsonpath: "$.results.PipelineRuns.Success.pending.avg"
+    description: "Average duration for pending PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_running_avg"
+    jsonpath: "$.results.PipelineRuns.Success.running.avg"
+    description: "Average duration for running PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # TaskRunsToPods_creation
+  - name: "results_TaskRunsToPods_creationTimestampDiff_mean"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.mean"
+    description: "Mean time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  - name: "results_TaskRunsToPods_creationTimestampDiff_max"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.max"
+    description: "Maximum time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeController_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-controller\".restarts.range"
+    description: "pipelinesAsCodeController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeWatcher_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-watcher\".restarts.range"
+    description: "pipelinesAsCodeWatcher restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonEventsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-events-controller\".restarts.range"
+    description: "tektonEventsController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesRemoteResolvers_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-remote-resolvers\".restarts.range"
+    description: "tektonPipelinesRemoteResolvers restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-controller\".restarts.range"
+    description: "tektonTriggersController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersCoreInterceptors_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-core-interceptors\".restarts.range"
+    description: "tektonTriggersCoreInterceptors restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-webhook\".restarts.range"
+    description: "tektonTriggersWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tknCliServe_restarts_range"
+    jsonpath: "$.measurements.\"tkn-cli-serve\".restarts.range"
+    description: "tkn-cli-serve restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null

--- a/tools/horreum/horreum_pipeline/horreum_pipeline_qbt_deployement.yaml
+++ b/tools/horreum/horreum_pipeline/horreum_pipeline_qbt_deployement.yaml
@@ -1,0 +1,759 @@
+# Horreum Fields Configuration
+# This file defines the fields to extract from performance data, their change detection settings,
+# and grouping information for comprehensive monitoring
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"  # Options: relativeDifference, fixedThreshold, hunter
+  window: 10                   # Number of data points to analyze
+  min_previous: 5              # Minimum previous data points required
+  threshold: 0.10              # Default 10% change threshold
+
+# Change detection groups with specific configurations
+change_detection_groups:
+  "cpu":
+    description: "CPU metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+    model: "relativeDifference"
+
+  "etcdMvccDb":
+    description: "etcd database metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "memory":
+    description: "memory metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 990
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3960
+      min_inclusive: true
+      max_enabled: false
+
+  "PipelineRuns_TaskRuns_duration":
+    description: "PLRs/TRs duration metrics"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "TaskRunsToPods_creation":
+    description: "TaskRun-to-Pods creation lag"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "controller_cpu":
+    description: "Controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.29194
+      max_inclusive: true
+      min_enabled: false
+  
+  "controller_memory":
+    description: "Controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 782432256
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_cpu":
+    description: "Webhook CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.26316
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_memory":
+    description: "Webhook memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 270742323
+      max_inclusive: true
+      min_enabled: false
+
+  "workqueue_depth":
+    description: "Workqueue depth metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 231.788
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 912066764
+      max_inclusive: true
+      min_enabled: false
+  
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0103131
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 19.063
+      max_inclusive: true
+      min_enabled: false
+# Test definition
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Scaling Pipelines test-qbt_deployement"
+  folder: "Openshift-pipelines"
+  description: "Results of this Prow job: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly/"
+  datastoreId: 1  # Assuming default datastore
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_concurrent
+    - parameters_test_total
+    - deployment_haConfig_controllerType
+    - deployment_qbtConfig_qbtEnabled
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  # JSON schema metadata
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. math)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightlyBuild_pipelinesControllerGitCommit"
+    jsonpath: "$.deployment.nightly_build.pipelines_controller_git_commit"
+    description: "Upstream tektoncd/pipeline git SHA (controller image upstream-vcs-ref)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for pipelines controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # tekton-pipelines-controller
+  - name: "measurements_tektonPipelinesController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesController_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-pipelines-webhook
+  - name: "measurements_tektonPipelinesWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-operator-proxy-webhook
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate" #"cpu"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size" #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration" #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  # Controller workqueue & latency
+  - name: "measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean"
+    description: "Mean Tekton Pipelines controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "workqueue_depth" #"cpu"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_mean"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.mean"
+    description: "Mean Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_max"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.max"
+    description: "Maximum Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  # PipelineRuns_TaskRuns_duration
+  - name: "results_PipelineRuns_duration_avg"
+    jsonpath: "$.results.PipelineRuns.duration.avg"
+    description: "Average duration for PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_duration_avg"
+    jsonpath: "$.results.TaskRuns.duration.avg"
+    description: "Average duration for TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_pending_avg"
+    jsonpath: "$.results.TaskRuns.Success.pending.avg"
+    description: "Average pending time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_running_avg"
+    jsonpath: "$.results.TaskRuns.Success.running.avg"
+    description: "Average running time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_duration_avg"
+    jsonpath: "$.results.TaskRuns.Success.duration.avg"
+    description: "Average duration for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_duration_avg"
+    jsonpath: "$.results.PipelineRuns.Success.duration.avg"
+    description: "Average duration for successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_pending_avg"
+    jsonpath: "$.results.PipelineRuns.Success.pending.avg"
+    description: "Average duration for pending PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_running_avg"
+    jsonpath: "$.results.PipelineRuns.Success.running.avg"
+    description: "Average duration for running PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # TaskRunsToPods_creation
+  - name: "results_TaskRunsToPods_creationTimestampDiff_mean"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.mean"
+    description: "Mean time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  - name: "results_TaskRunsToPods_creationTimestampDiff_max"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.max"
+    description: "Maximum time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeController_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-controller\".restarts.range"
+    description: "pipelinesAsCodeController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeWatcher_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-watcher\".restarts.range"
+    description: "pipelinesAsCodeWatcher restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonEventsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-events-controller\".restarts.range"
+    description: "tektonEventsController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesRemoteResolvers_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-remote-resolvers\".restarts.range"
+    description: "tektonPipelinesRemoteResolvers restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-controller\".restarts.range"
+    description: "tektonTriggersController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersCoreInterceptors_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-core-interceptors\".restarts.range"
+    description: "tektonTriggersCoreInterceptors restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-webhook\".restarts.range"
+    description: "tektonTriggersWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tknCliServe_restarts_range"
+    jsonpath: "$.measurements.\"tkn-cli-serve\".restarts.range"
+    description: "tkn-cli-serve restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null

--- a/tools/horreum/horreum_pipeline/horreum_pipeline_standard.yaml
+++ b/tools/horreum/horreum_pipeline/horreum_pipeline_standard.yaml
@@ -1,0 +1,759 @@
+# Horreum Fields Configuration
+# This file defines the fields to extract from performance data, their change detection settings,
+# and grouping information for comprehensive monitoring
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"  # Options: relativeDifference, fixedThreshold, hunter
+  window: 10                   # Number of data points to analyze
+  min_previous: 5              # Minimum previous data points required
+  threshold: 0.10              # Default 10% change threshold
+
+# Change detection groups with specific configurations
+change_detection_groups:
+  "cpu":
+    description: "CPU metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+    model: "relativeDifference"
+
+  "etcdMvccDb":
+    description: "etcd database metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "memory":
+    description: "memory metrics"
+    threshold: 0.10
+    window: 5
+    min_previous: 5
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 990
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3960
+      min_inclusive: true
+      max_enabled: false
+
+  "PipelineRuns_TaskRuns_duration":
+    description: "PLRs/TRs duration metrics"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "TaskRunsToPods_creation":
+    description: "TaskRun-to-Pods creation lag"
+    threshold: 0.20
+    window: 10
+    min_previous: 5
+    model: "relativeDifference"
+
+  "controller_cpu":
+    description: "Controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.09995
+      max_inclusive: true
+      min_enabled: false
+  
+  "controller_memory":
+    description: "Controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 720896819
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_cpu":
+    description: "Webhook CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.05182
+      max_inclusive: true
+      min_enabled: false
+  
+  "webhook_memory":
+    description: "Webhook memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 248512512
+      max_inclusive: true
+      min_enabled: false
+
+  "workqueue_depth":
+    description: "Workqueue depth metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 499.234
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 429260390
+      max_inclusive: true
+      min_enabled: false
+  
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0063534
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 13.313
+      max_inclusive: true
+      min_enabled: false
+# Test definition
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Scaling Pipelines test-standard"
+  folder: "Openshift-pipelines"
+  description: "Results of this Prow job: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-pipelines-performance-main-max-concurrency-downstream-nightly/"
+  datastoreId: 1  # Assuming default datastore
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_concurrent
+    - parameters_test_total
+    - deployment_haConfig_controllerType
+    - deployment_qbtConfig_qbtEnabled
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  # JSON schema metadata
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. math)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightlyBuild_pipelinesControllerGitCommit"
+    jsonpath: "$.deployment.nightly_build.pipelines_controller_git_commit"
+    description: "Upstream tektoncd/pipeline git SHA (controller image upstream-vcs-ref)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for pipelines controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # tekton-pipelines-controller
+  - name: "measurements_tektonPipelinesController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "controller_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesController_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-pipelines-webhook
+  - name: "measurements_tektonPipelinesWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_cpu" #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: "webhook_memory" #"memory"
+
+  - name: "measurements_tektonPipelinesWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-pipelines-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # tekton-operator-proxy-webhook
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.mean"
+    description: "Mean CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_cpu_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".cpu.max"
+    description: "Maximum CPU usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_mean"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.mean"
+    description: "Mean memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_tektonOperatorProxyWebhook_memory_max"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".memory.max"
+    description: "Maximum memory usage for tekton-operator-proxy-webhook"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate" #"cpu"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"memory"
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"cpu"
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size" #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration" #"etcdMvccDb"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null #"etcdMvccDb"
+
+  # Controller workqueue & latency
+  - name: "measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_pipelines_controller_workqueue_depth.mean"
+    description: "Mean Tekton Pipelines controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "workqueue_depth" #"cpu"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_mean"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.mean"
+    description: "Mean Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "measurements_tektonPipelinesControllerClientLatencyAverage_max"
+    jsonpath: "$.measurements.tekton_pipelines_controller_client_latency_average.max"
+    description: "Maximum Tekton Pipelines controller HTTP client latency"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  # PipelineRuns_TaskRuns_duration
+  - name: "results_PipelineRuns_duration_avg"
+    jsonpath: "$.results.PipelineRuns.duration.avg"
+    description: "Average duration for PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_duration_avg"
+    jsonpath: "$.results.TaskRuns.duration.avg"
+    description: "Average duration for TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_pending_avg"
+    jsonpath: "$.results.TaskRuns.Success.pending.avg"
+    description: "Average pending time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_running_avg"
+    jsonpath: "$.results.TaskRuns.Success.running.avg"
+    description: "Average running time for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_TaskRuns_Success_duration_avg"
+    jsonpath: "$.results.TaskRuns.Success.duration.avg"
+    description: "Average duration for successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_duration_avg"
+    jsonpath: "$.results.PipelineRuns.Success.duration.avg"
+    description: "Average duration for successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_pending_avg"
+    jsonpath: "$.results.PipelineRuns.Success.pending.avg"
+    description: "Average duration for pending PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  - name: "results_PipelineRuns_Success_running_avg"
+    jsonpath: "$.results.PipelineRuns.Success.running.avg"
+    description: "Average duration for running PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_duration"
+
+  # TaskRunsToPods_creation
+  - name: "results_TaskRunsToPods_creationTimestampDiff_mean"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.mean"
+    description: "Mean time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  - name: "results_TaskRunsToPods_creationTimestampDiff_max"
+    jsonpath: "$.results.TaskRuns_to_Pods.creationTimestamp_diff.max"
+    description: "Maximum time difference between TaskRun and Pod creation"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRunsToPods_creation"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeController_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-controller\".restarts.range"
+    description: "pipelinesAsCodeController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_pipelinesAsCodeWatcher_restarts_range"
+    jsonpath: "$.measurements.\"pipelines-as-code-watcher\".restarts.range"
+    description: "pipelinesAsCodeWatcher restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonEventsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-events-controller\".restarts.range"
+    description: "tektonEventsController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesRemoteResolvers_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-remote-resolvers\".restarts.range"
+    description: "tektonPipelinesRemoteResolvers restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-controller\".restarts.range"
+    description: "tektonTriggersController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersCoreInterceptors_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-core-interceptors\".restarts.range"
+    description: "tektonTriggersCoreInterceptors restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonTriggersWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-triggers-webhook\".restarts.range"
+    description: "tektonTriggersWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tknCliServe_restarts_range"
+    jsonpath: "$.measurements.\"tkn-cli-serve\".restarts.range"
+    description: "tkn-cli-serve restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -15,6 +15,38 @@ fi
 
 TEST_NAMESPACE="${TEST_NAMESPACE:-1}"
 
+horreum_test_name() {
+    if [[ "${TEST_SCENARIO:-}" == *signing* ]]; then
+        echo "OpenShift Pipelines Chains signing test"
+        return
+    fi
+
+    local ha_replicas="${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-0}"
+    local ha_enabled=false
+    if [[ -n "${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-}" && "${ha_replicas}" != "0" ]]; then
+        ha_enabled=true
+    fi
+
+    local qbt_enabled=false
+    if [[ -n "${DEPLOYMENT_PIPELINES_KUBE_API_QPS:-}" || -n "${DEPLOYMENT_PIPELINES_KUBE_API_BURST:-}" || -n "${DEPLOYMENT_PIPELINES_THREADS_PER_CONTROLLER:-}" ]]; then
+        qbt_enabled=true
+    fi
+
+    local controller_type="${DEPLOYMENT_PIPELINES_CONTROLLER_TYPE:-deployments}"
+
+    if [[ "$ha_enabled" == false && "$qbt_enabled" == false ]]; then
+        echo "Scaling Pipelines test-standard"
+    elif [[ "$ha_enabled" == false && "$qbt_enabled" == true ]]; then
+        echo "Scaling Pipelines test-qbt_deployement"
+    elif [[ "$ha_enabled" == true && "$qbt_enabled" == false && "$controller_type" == "statefulSets" ]]; then
+        echo "Scaling Pipelines test-ha_statefulsets"
+    elif [[ "$ha_enabled" == true && "$qbt_enabled" == false ]]; then
+        echo "Scaling Pipelines test-ha_deployement"
+    elif [[ "$ha_enabled" == true && "$qbt_enabled" == true ]]; then
+        echo "Scaling Pipelines test-ha_qbt"
+    fi
+}
+
 echo "$(date -Ins --utc) dumping basic results to data files"
 
 # Update if file already exists 
@@ -22,7 +54,7 @@ if [ ! -f $output ]; then
 
 cat <<EOF >$output
 {
-    "name": "$(if [[ "${TEST_SCENARIO:-}" == *signing* ]]; then echo "OpenShift Pipelines Chains signing test"; else echo "OpenShift Pipelines scalingPipelines test"; fi)",
+    "name": "$(horreum_test_name)",
     "results": {
         "started": "$started",
         "ended": "$ended"


### PR DESCRIPTION
## Summary

Refactors Horreum performance test configuration to support scenario-specific monitoring with five separate YAML configs instead of one monolithic file.

## Changes

**New scenario-specific configs** under `tools/horreum/horreum_pipeline/`:
- `horreum_pipeline_standard.yaml` – Standard deployment
- `horreum_pipeline_qbt_deployement.yaml` – QBT-only
- `horreum_pipeline_ha_deployement.yaml` – HA with Deployments
- `horreum_pipeline_ha_statefulsets.yaml` – HA with StatefulSets
- `horreum_pipeline_ha_qbt.yaml` – HA + QBT

**Dynamic test name assignment**:
- `stats.sh`: New `horreum_test_name()` function detects scenario from deployment env vars
- `prow-to-storage.sh`: Patches `.name` field in JSON before Horreum upload

**Documentation & utilities**:
- Updated `tools/horreum/README.md` with scenario mapping table

## Why

Different deployment scenarios have different performance baselines. Scenario-specific configs enable accurate change detection, cleaner alerting, and easier maintenance.