### PR TITLE
Split Chains signing test into per-scenario Horreum configs with fixed thresholds

### DIFF
--- a/tools/horreum/horreum_chains/horreum_chains_ha.yaml
+++ b/tools/horreum/horreum_chains/horreum_chains_ha.yaml
@@ -1,0 +1,658 @@
+# Horreum Fields Configuration — Chains signing test (ha: ha=true, qbt=false)
+# Shares the same schema as Pipelines (same URI), but has its own test definition
+# and change detection variables for Chains-specific metrics.
+#
+# IMPORTANT: Run with CLEANUP_LABELS=false to avoid deleting Pipelines labels
+# from the shared schema.
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"
+  window: 10
+  min_previous: 5
+  threshold: 0.10
+
+# Change detection groups for Chains test — ha scenario
+change_detection_groups:
+  "chains_cpu":
+    description: "Chains controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 7.49528
+      max_inclusive: true
+      min_enabled: false
+
+  "chains_memory":
+    description: "Chains controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 5630957978
+      max_inclusive: true
+      min_enabled: false
+
+  "chains_workqueue":
+    description: "Chains controller workqueue depth"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 21480.67364
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 576611942
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0077004
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 30.081
+      max_inclusive: true
+      min_enabled: false
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3700
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3700
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_count":
+    description: "All runs must be signed (varies with TEST_TOTAL)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 4625
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_duration":
+    description: "Signing duration metrics (lower is better)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 1220.37316
+      max_inclusive: true
+      min_enabled: false
+
+  "signing_throughput":
+    description: "Signing throughput metrics (higher is better)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 13.67604
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_unsigned_count":
+    description: "No runs should remain unsigned"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "PipelineRuns_TaskRuns_Failed_count":
+    description: "Number of failing PipelineRuns and TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+# Test definition — Chains signing test (standard)
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Chains signing test-ha"
+  folder: "Openshift-pipelines"
+  description: "Chains signing performance test results for ha (ha=true, qbt=false) configuration"
+  datastoreId: 1
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_total
+    - deployment_qbtConfig_qbtEnabled
+    - metadata_env_TEST_SCENARIO
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition — SAME as Pipelines (shared schema)
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # =========================================================================
+  # Shared labels (also in horreum_pipeline_fields.yaml)
+  # =========================================================================
+
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. signing-tr-tekton-bigbang)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_PipelineRuns_count_failed"
+    jsonpath: "$.results.PipelineRuns.count.failed"
+    description: "Number of failed PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_failed"
+    jsonpath: "$.results.TaskRuns.count.failed"
+    description: "Number of failed TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # =========================================================================
+  # Chains-specific labels
+  # =========================================================================
+
+  # Chains controller CPU
+  - name: "measurements_tektonChainsController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_cpu"
+
+  - name: "measurements_tektonChainsController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Chains controller memory
+  - name: "measurements_tektonChainsController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.mean"
+    description: "Mean memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_memory"
+
+  - name: "measurements_tektonChainsController_memory_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.max"
+    description: "Maximum memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Chains controller restarts
+  - name: "measurements_tektonChainsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".restarts.range"
+    description: "tekton-chains-controller restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  # Chains controller workqueue depth
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.mean"
+    description: "Mean Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_workqueue"
+
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_max"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.max"
+    description: "Maximum Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Signing metrics — PipelineRuns
+  - name: "results_PipelineRuns_signing_count_signed_true"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_true"
+    description: "Number of PipelineRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_PipelineRuns_signing_count_signed_false"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_false"
+    description: "Number of PipelineRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_count_unsigned"
+    jsonpath: "$.results.PipelineRuns.signing.count.unsigned"
+    description: "Number of PipelineRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_duration"
+    jsonpath: "$.results.PipelineRuns.signing.duration"
+    description: "PipelineRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_duration"
+
+  - name: "results_PipelineRuns_signing_throughput"
+    jsonpath: "$.results.PipelineRuns.signing.throughput"
+    description: "PipelineRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"
+
+  # Signing metrics — TaskRuns
+  - name: "results_TaskRuns_signing_count_signed_true"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_true"
+    description: "Number of TaskRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_TaskRuns_signing_count_signed_false"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_false"
+    description: "Number of TaskRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_count_unsigned"
+    jsonpath: "$.results.TaskRuns.signing.count.unsigned"
+    description: "Number of TaskRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_duration"
+    jsonpath: "$.results.TaskRuns.signing.duration"
+    description: "TaskRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_duration"
+
+  - name: "results_TaskRuns_signing_throughput"
+    jsonpath: "$.results.TaskRuns.signing.throughput"
+    description: "TaskRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"

--- a/tools/horreum/horreum_chains/horreum_chains_ha_qbt.yaml
+++ b/tools/horreum/horreum_chains/horreum_chains_ha_qbt.yaml
@@ -1,0 +1,658 @@
+# Horreum Fields Configuration — Chains signing test (ha_qbt: ha=true, qbt=true)
+# Shares the same schema as Pipelines (same URI), but has its own test definition
+# and change detection variables for Chains-specific metrics.
+#
+# IMPORTANT: Run with CLEANUP_LABELS=false to avoid deleting Pipelines labels
+# from the shared schema.
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"
+  window: 10
+  min_previous: 5
+  threshold: 0.10
+
+# Change detection groups for Chains test — ha_qbt scenario
+change_detection_groups:
+  "chains_cpu":
+    description: "Chains controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 9.6229
+      max_inclusive: true
+      min_enabled: false
+
+  "chains_memory":
+    description: "Chains controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 43552604160
+      max_inclusive: true
+      min_enabled: false
+
+  "chains_workqueue":
+    description: "Chains controller workqueue depth"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 15244.57824
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 639736218
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0114894
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 45.834
+      max_inclusive: true
+      min_enabled: false
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3700
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3700
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_count":
+    description: "All runs must be signed (varies with TEST_TOTAL)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 4625
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_duration":
+    description: "Signing duration metrics (lower is better)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 243.83265
+      max_inclusive: true
+      min_enabled: false
+
+  "signing_throughput":
+    description: "Signing throughput metrics (higher is better)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 38.04828
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_unsigned_count":
+    description: "No runs should remain unsigned"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "PipelineRuns_TaskRuns_Failed_count":
+    description: "Number of failing PipelineRuns and TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+# Test definition — Chains signing test (standard)
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Chains signing test-ha_qbt"
+  folder: "Openshift-pipelines"
+  description: "Chains signing performance test results for ha_qbt (ha=true, qbt=true) configuration"
+  datastoreId: 1
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_total
+    - deployment_qbtConfig_qbtEnabled
+    - metadata_env_TEST_SCENARIO
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition — SAME as Pipelines (shared schema)
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # =========================================================================
+  # Shared labels (also in horreum_pipeline_fields.yaml)
+  # =========================================================================
+
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. signing-tr-tekton-bigbang)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_PipelineRuns_count_failed"
+    jsonpath: "$.results.PipelineRuns.count.failed"
+    description: "Number of failed PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_failed"
+    jsonpath: "$.results.TaskRuns.count.failed"
+    description: "Number of failed TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # =========================================================================
+  # Chains-specific labels
+  # =========================================================================
+
+  # Chains controller CPU
+  - name: "measurements_tektonChainsController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_cpu"
+
+  - name: "measurements_tektonChainsController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Chains controller memory
+  - name: "measurements_tektonChainsController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.mean"
+    description: "Mean memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_memory"
+
+  - name: "measurements_tektonChainsController_memory_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.max"
+    description: "Maximum memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Chains controller restarts
+  - name: "measurements_tektonChainsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".restarts.range"
+    description: "tekton-chains-controller restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  # Chains controller workqueue depth
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.mean"
+    description: "Mean Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_workqueue"
+
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_max"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.max"
+    description: "Maximum Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Signing metrics — PipelineRuns
+  - name: "results_PipelineRuns_signing_count_signed_true"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_true"
+    description: "Number of PipelineRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_PipelineRuns_signing_count_signed_false"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_false"
+    description: "Number of PipelineRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_count_unsigned"
+    jsonpath: "$.results.PipelineRuns.signing.count.unsigned"
+    description: "Number of PipelineRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_duration"
+    jsonpath: "$.results.PipelineRuns.signing.duration"
+    description: "PipelineRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_duration"
+
+  - name: "results_PipelineRuns_signing_throughput"
+    jsonpath: "$.results.PipelineRuns.signing.throughput"
+    description: "PipelineRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"
+
+  # Signing metrics — TaskRuns
+  - name: "results_TaskRuns_signing_count_signed_true"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_true"
+    description: "Number of TaskRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_TaskRuns_signing_count_signed_false"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_false"
+    description: "Number of TaskRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_count_unsigned"
+    jsonpath: "$.results.TaskRuns.signing.count.unsigned"
+    description: "Number of TaskRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_duration"
+    jsonpath: "$.results.TaskRuns.signing.duration"
+    description: "TaskRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_duration"
+
+  - name: "results_TaskRuns_signing_throughput"
+    jsonpath: "$.results.TaskRuns.signing.throughput"
+    description: "TaskRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"

--- a/tools/horreum/horreum_chains/horreum_chains_qbt.yaml
+++ b/tools/horreum/horreum_chains/horreum_chains_qbt.yaml
@@ -1,0 +1,658 @@
+# Horreum Fields Configuration — Chains signing test (qbt: ha=false, qbt=true)
+# Shares the same schema as Pipelines (same URI), but has its own test definition
+# and change detection variables for Chains-specific metrics.
+#
+# IMPORTANT: Run with CLEANUP_LABELS=false to avoid deleting Pipelines labels
+# from the shared schema.
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"
+  window: 10
+  min_previous: 5
+  threshold: 0.10
+
+# Change detection groups for Chains test — qbt scenario
+change_detection_groups:
+  "chains_cpu":
+    description: "Chains controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 4.8575
+      max_inclusive: true
+      min_enabled: false
+
+  "chains_memory":
+    description: "Chains controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 8914783437
+      max_inclusive: true
+      min_enabled: false
+
+  "chains_workqueue":
+    description: "Chains controller workqueue depth"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 7065.09195
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 558052147
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0061173
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 23.038
+      max_inclusive: true
+      min_enabled: false
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3700
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3700
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_count":
+    description: "All runs must be signed (varies with TEST_TOTAL)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 4625.7
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_duration":
+    description: "Signing duration metrics (lower is better)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 703.15288
+      max_inclusive: true
+      min_enabled: false
+
+  "signing_throughput":
+    description: "Signing throughput metrics (higher is better)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 10.35909
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_unsigned_count":
+    description: "No runs should remain unsigned"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "PipelineRuns_TaskRuns_Failed_count":
+    description: "Number of failing PipelineRuns and TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+# Test definition — Chains signing test (standard)
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Chains signing test-qbt"
+  folder: "Openshift-pipelines"
+  description: "Chains signing performance test results for qbt (ha=false, qbt=true) configuration"
+  datastoreId: 1
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_total
+    - deployment_qbtConfig_qbtEnabled
+    - metadata_env_TEST_SCENARIO
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition — SAME as Pipelines (shared schema)
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # =========================================================================
+  # Shared labels (also in horreum_pipeline_fields.yaml)
+  # =========================================================================
+
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. signing-tr-tekton-bigbang)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_PipelineRuns_count_failed"
+    jsonpath: "$.results.PipelineRuns.count.failed"
+    description: "Number of failed PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_failed"
+    jsonpath: "$.results.TaskRuns.count.failed"
+    description: "Number of failed TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # =========================================================================
+  # Chains-specific labels
+  # =========================================================================
+
+  # Chains controller CPU
+  - name: "measurements_tektonChainsController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_cpu"
+
+  - name: "measurements_tektonChainsController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Chains controller memory
+  - name: "measurements_tektonChainsController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.mean"
+    description: "Mean memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_memory"
+
+  - name: "measurements_tektonChainsController_memory_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.max"
+    description: "Maximum memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Chains controller restarts
+  - name: "measurements_tektonChainsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".restarts.range"
+    description: "tekton-chains-controller restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  # Chains controller workqueue depth
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.mean"
+    description: "Mean Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_workqueue"
+
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_max"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.max"
+    description: "Maximum Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Signing metrics — PipelineRuns
+  - name: "results_PipelineRuns_signing_count_signed_true"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_true"
+    description: "Number of PipelineRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_PipelineRuns_signing_count_signed_false"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_false"
+    description: "Number of PipelineRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_count_unsigned"
+    jsonpath: "$.results.PipelineRuns.signing.count.unsigned"
+    description: "Number of PipelineRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_duration"
+    jsonpath: "$.results.PipelineRuns.signing.duration"
+    description: "PipelineRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_duration"
+
+  - name: "results_PipelineRuns_signing_throughput"
+    jsonpath: "$.results.PipelineRuns.signing.throughput"
+    description: "PipelineRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"
+
+  # Signing metrics — TaskRuns
+  - name: "results_TaskRuns_signing_count_signed_true"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_true"
+    description: "Number of TaskRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_TaskRuns_signing_count_signed_false"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_false"
+    description: "Number of TaskRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_count_unsigned"
+    jsonpath: "$.results.TaskRuns.signing.count.unsigned"
+    description: "Number of TaskRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_duration"
+    jsonpath: "$.results.TaskRuns.signing.duration"
+    description: "TaskRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_duration"
+
+  - name: "results_TaskRuns_signing_throughput"
+    jsonpath: "$.results.TaskRuns.signing.throughput"
+    description: "TaskRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"

--- a/tools/horreum/horreum_chains/horreum_chains_standard.yaml
+++ b/tools/horreum/horreum_chains/horreum_chains_standard.yaml
@@ -1,0 +1,658 @@
+# Horreum Fields Configuration — Chains signing test (standard: ha=false, qbt=false)
+# Shares the same schema as Pipelines (same URI), but has its own test definition
+# and change detection variables for Chains-specific metrics.
+#
+# IMPORTANT: Run with CLEANUP_LABELS=false to avoid deleting Pipelines labels
+# from the shared schema.
+
+# Global configuration
+global:
+  owner: "Openshift-pipelines-team"
+  access: "PUBLIC"
+
+# Global change detection defaults
+change_detection_defaults:
+  model: "relativeDifference"
+  window: 10
+  min_previous: 5
+  threshold: 0.10
+
+# Change detection groups for Chains test — standard scenario
+change_detection_groups:
+  "chains_cpu":
+    description: "Chains controller CPU metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 1.49452
+      max_inclusive: true
+      min_enabled: false
+
+  "chains_memory":
+    description: "Chains controller memory metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 989016883
+      max_inclusive: true
+      min_enabled: false
+
+  "chains_workqueue":
+    description: "Chains controller workqueue depth"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 8125.431
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_database_size":
+    description: "Etcd database size metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 438724198
+      max_inclusive: true
+      min_enabled: false
+
+  "etcd_request_duration":
+    description: "Etcd request duration metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0.0188687
+      max_inclusive: true
+      min_enabled: false
+
+  "cluster_cpu_usage_seconds_total_rate":
+    description: "Cluster CPU usage seconds total rate metrics"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 19.792
+      max_inclusive: true
+      min_enabled: false
+
+  "PipelineRuns_Succeeded_count":
+    description: "Number of successful PipelineRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3700
+      min_inclusive: true
+      max_enabled: false
+
+  "TaskRuns_Succeeded_count":
+    description: "Number of successful TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 3700
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_count":
+    description: "All runs must be signed (varies with TEST_TOTAL)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 4626.4
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_duration":
+    description: "Signing duration metrics (lower is better)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 3231.83444
+      max_inclusive: true
+      min_enabled: false
+
+  "signing_throughput":
+    description: "Signing throughput metrics (higher is better)"
+    model: "fixedThreshold"
+    fixed_threshold:
+      min_enabled: true
+      min_value: 2.04289
+      min_inclusive: true
+      max_enabled: false
+
+  "signing_unsigned_count":
+    description: "No runs should remain unsigned"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "PipelineRuns_TaskRuns_Failed_count":
+    description: "Number of failing PipelineRuns and TaskRuns"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+  "restarts":
+    description: "Pod and container restart counts"
+    model: "fixedThreshold"
+    fixed_threshold:
+      max_enabled: true
+      max_value: 0
+      max_inclusive: true
+      min_enabled: false
+
+# Test definition — Chains signing test (standard)
+test:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  name: "Chains signing test-standard"
+  folder: "Openshift-pipelines"
+  description: "Chains signing performance test results for standard (ha=false, qbt=false) configuration"
+  datastoreId: 1
+  timelineLabels: ["started"]
+  timelineFunction: "value => new Date(value).getTime()"
+  fingerprintLabels:
+    - deployment_haConfig_haEnabled
+    - deployment_version
+    - parameters_test_total
+    - deployment_qbtConfig_qbtEnabled
+    - metadata_env_TEST_SCENARIO
+  fingerprintFilter: "value => value !== null"
+  notificationsEnabled: true
+
+# Schema definition — SAME as Pipelines (shared schema)
+schema:
+  access: "PUBLIC"
+  owner: "Openshift-pipelines-team"
+  uri: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+  name: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+  description: "Schema for OpenShift Pipelines scalingPipelines performance test data"
+  json_schema:
+    $schema: "https://json-schema.org/draft/2020-12/schema"
+    $id: "urn:openshift-pipelines-perfscale-scalingPipelines:0.2"
+    title: "openshift-pipelines-perfscale-scalingPipelines-0.2"
+    description: "Schema for OpenShift Pipelines performance benchmark data generated from field configuration"
+
+# Field definitions
+fields:
+  # =========================================================================
+  # Shared labels (also in horreum_pipeline_fields.yaml)
+  # =========================================================================
+
+  # Metadata & identifiers
+  - name: "started"
+    jsonpath: "$.started"
+    description: "Run start timestamp"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "metadata_env_BUILD_ID"
+    jsonpath: "$.metadata.env.BUILD_ID"
+    description: "Prow build ID"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_SUBJOB_BUILD_ID"
+    jsonpath: "$.metadata.env.SUBJOB_BUILD_ID"
+    description: "Sub-job build ID (unique per concurrency level)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "metadata_env_TEST_SCENARIO"
+    jsonpath: "$.metadata.env.TEST_SCENARIO"
+    description: "Test scenario name (e.g. signing-tr-tekton-bigbang)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Test parameters
+  - name: "parameters_test_concurrent"
+    jsonpath: "$.parameters.test.concurrent"
+    description: "Test concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "parameters_test_total"
+    jsonpath: "$.parameters.test.total"
+    description: "Total PipelineRuns per concurrency level"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # Deployment configuration
+  - name: "deployment_version"
+    jsonpath: "$.deployment.version"
+    description: "Deployment version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_nightly"
+    jsonpath: "$.deployment.is_nightly_build"
+    description: "Whether this is a nightly build"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haEnabled"
+    jsonpath: "$.deployment.ha_config.ha_enabled"
+    description: "HA mode enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_haReplicas"
+    jsonpath: "$.deployment.ha_config.ha_replicas"
+    description: "Number of HA replicas for controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_haConfig_controllerType"
+    jsonpath: "$.deployment.ha_config.controller_type"
+    description: "Controller type (deployments or statefulsets)"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_ocpVersion"
+    jsonpath: "$.deployment.ocp_version"
+    description: "OpenShift cluster version"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_qbtEnabled"
+    jsonpath: "$.deployment.qbt_config.qbt_enabled"
+    description: "QBT enabled flag"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiQps"
+    jsonpath: "$.deployment.qbt_config.kube_api_qps"
+    description: "Kube API queries per second limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_kubeApiBurst"
+    jsonpath: "$.deployment.qbt_config.kube_api_burst"
+    description: "Kube API burst limit"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  - name: "deployment_qbtConfig_threadsPerController"
+    jsonpath: "$.deployment.qbt_config.threads_per_controller"
+    description: "Number of threads per controller"
+    filtering: true
+    metrics: false
+    change_detection_group: null
+
+  # apiserver
+  - name: "measurements_apiserver_cpu_mean"
+    jsonpath: "$.measurements.apiserver.cpu.mean"
+    description: "Mean CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_cpu_max"
+    jsonpath: "$.measurements.apiserver.cpu.max"
+    description: "Maximum CPU usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_mean"
+    jsonpath: "$.measurements.apiserver.memory.mean"
+    description: "Mean memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserver_memory_max"
+    jsonpath: "$.measurements.apiserver.memory.max"
+    description: "Max memory usage for API server"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # kube-apiserver
+  - name: "measurements_kubeApiserver_cpu_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.mean"
+    description: "Mean CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_cpu_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".cpu.max"
+    description: "Maximum CPU usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_mean"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.mean"
+    description: "Mean memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_kubeApiserver_memory_max"
+    jsonpath: "$.measurements.\"kube-apiserver\".memory.max"
+    description: "Max memory usage for kube-apiserver"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Cluster-level resource metrics
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_mean"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.mean"
+    description: "Mean total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: "cluster_cpu_usage_seconds_total_rate"
+
+  - name: "measurements_clusterCpuUsageSecondsTotalRate_max"
+    jsonpath: "$.measurements.cluster_cpu_usage_seconds_total_rate.max"
+    description: "Maximum total CPU usage rate across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_mean"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.mean"
+    description: "Mean CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_workersAvgCpuUsagePercentage_max"
+    jsonpath: "$.measurements.workers_avg_cpu_usage_percentage.max"
+    description: "Maximum CPU usage percentage across worker nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_mean"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.mean"
+    description: "Mean total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_clusterMemoryUsageRssTotal_max"
+    jsonpath: "$.measurements.cluster_memory_usage_rss_total.max"
+    description: "Maximum total RSS memory usage across all cluster nodes"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_apiserverRequestTotalRate_mean"
+    jsonpath: "$.measurements.apiserver_request_total_rate.mean"
+    description: "Mean API server request rate"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # etcd metrics
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.mean"
+    description: "Mean etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_database_size"
+
+  - name: "measurements_etcdMvccDbTotalSizeInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_bytes_average.max"
+    description: "Maximum etcd database total size"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.mean"
+    description: "Mean etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdMvccDbTotalSizeInUseInBytesAverage_max"
+    jsonpath: "$.measurements.etcd_mvcc_db_total_size_in_use_in_bytes_average.max"
+    description: "Maximum etcd database size in use"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_mean"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.mean"
+    description: "Mean etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: "etcd_request_duration"
+
+  - name: "measurements_etcdRequestDurationSecondsAverage_max"
+    jsonpath: "$.measurements.etcd_request_duration_seconds_average.max"
+    description: "Maximum etcd request duration"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # PipelineRuns and TaskRuns counts
+  - name: "results_PipelineRuns_count_succeeded"
+    jsonpath: "$.results.PipelineRuns.count.succeeded"
+    description: "Number of successful PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_Succeeded_count"
+
+  - name: "results_PipelineRuns_count_failed"
+    jsonpath: "$.results.PipelineRuns.count.failed"
+    description: "Number of failed PipelineRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  - name: "results_TaskRuns_count_succeeded"
+    jsonpath: "$.results.TaskRuns.count.succeeded"
+    description: "Number of successful TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "TaskRuns_Succeeded_count"
+
+  - name: "results_TaskRuns_count_failed"
+    jsonpath: "$.results.TaskRuns.count.failed"
+    description: "Number of failed TaskRuns"
+    filtering: false
+    metrics: true
+    change_detection_group: "PipelineRuns_TaskRuns_Failed_count"
+
+  # restarts
+  - name: "measurements_apiserver_restarts_range"
+    jsonpath: "$.measurements.apiserver.restarts.range"
+    description: "apiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_etcd_restarts_range"
+    jsonpath: "$.measurements.etcd.restarts.range"
+    description: "etcd restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_kubeApiserver_restarts_range"
+    jsonpath: "$.measurements.\"kube-apiserver\".restarts.range"
+    description: "kubeApiserver restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-controller\".restarts.range"
+    description: "tektonPipelinesController restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonPipelinesWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-pipelines-webhook\".restarts.range"
+    description: "tektonPipelinesWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_tektonOperatorProxyWebhook_restarts_range"
+    jsonpath: "$.measurements.\"tekton-operator-proxy-webhook\".restarts.range"
+    description: "tektonOperatorProxyWebhook restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  - name: "measurements_schedulerPendingPodsCount_range"
+    jsonpath: "$.measurements.scheduler_pending_pods_count.range"
+    description: "Range of pending pods in the Kubernetes scheduler"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # =========================================================================
+  # Chains-specific labels
+  # =========================================================================
+
+  # Chains controller CPU
+  - name: "measurements_tektonChainsController_cpu_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.mean"
+    description: "Mean CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_cpu"
+
+  - name: "measurements_tektonChainsController_cpu_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".cpu.max"
+    description: "Maximum CPU usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Chains controller memory
+  - name: "measurements_tektonChainsController_memory_mean"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.mean"
+    description: "Mean memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_memory"
+
+  - name: "measurements_tektonChainsController_memory_max"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".memory.max"
+    description: "Maximum memory usage for tekton-chains-controller"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Chains controller restarts
+  - name: "measurements_tektonChainsController_restarts_range"
+    jsonpath: "$.measurements.\"tekton-chains-controller\".restarts.range"
+    description: "tekton-chains-controller restart count"
+    filtering: false
+    metrics: true
+    change_detection_group: "restarts"
+
+  # Chains controller workqueue depth
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_mean"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.mean"
+    description: "Mean Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: "chains_workqueue"
+
+  - name: "measurements_tektonChainsControllerWorkqueueDepth_max"
+    jsonpath: "$.measurements.tekton_tekton_chains_controller_workqueue_depth.max"
+    description: "Maximum Tekton Chains controller workqueue depth"
+    filtering: false
+    metrics: true
+    change_detection_group: null
+
+  # Signing metrics — PipelineRuns
+  - name: "results_PipelineRuns_signing_count_signed_true"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_true"
+    description: "Number of PipelineRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_PipelineRuns_signing_count_signed_false"
+    jsonpath: "$.results.PipelineRuns.signing.count.signed_false"
+    description: "Number of PipelineRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_count_unsigned"
+    jsonpath: "$.results.PipelineRuns.signing.count.unsigned"
+    description: "Number of PipelineRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_PipelineRuns_signing_duration"
+    jsonpath: "$.results.PipelineRuns.signing.duration"
+    description: "PipelineRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_duration"
+
+  - name: "results_PipelineRuns_signing_throughput"
+    jsonpath: "$.results.PipelineRuns.signing.throughput"
+    description: "PipelineRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"
+
+  # Signing metrics — TaskRuns
+  - name: "results_TaskRuns_signing_count_signed_true"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_true"
+    description: "Number of TaskRuns signed successfully"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_count"
+
+  - name: "results_TaskRuns_signing_count_signed_false"
+    jsonpath: "$.results.TaskRuns.signing.count.signed_false"
+    description: "Number of TaskRuns with signing failed"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_count_unsigned"
+    jsonpath: "$.results.TaskRuns.signing.count.unsigned"
+    description: "Number of TaskRuns that remained unsigned"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_unsigned_count"
+
+  - name: "results_TaskRuns_signing_duration"
+    jsonpath: "$.results.TaskRuns.signing.duration"
+    description: "TaskRun signing window duration (last_signed - first_signed)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_duration"
+
+  - name: "results_TaskRuns_signing_throughput"
+    jsonpath: "$.results.TaskRuns.signing.throughput"
+    description: "TaskRun signing throughput (signed/duration)"
+    filtering: false
+    metrics: true
+    change_detection_group: "signing_throughput"

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -22,8 +22,30 @@ horreum_test_name() {
     fi
 
     if [[ "${TEST_SCENARIO:-}" == *signing* ]]; then
-        echo "OpenShift Pipelines Chains signing test"
-        return
+        local chains_ha_replicas="${DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS:-0}"
+        local chains_ha_enabled=false
+        if [[ -n "${DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS:-}" && "${chains_ha_replicas}" != "0" ]]; then
+            chains_ha_enabled=true
+        fi
+
+        local chains_qbt_enabled=false
+        if [[ -n "${DEPLOYMENT_CHAINS_KUBE_API_QPS:-}" || -n "${DEPLOYMENT_CHAINS_KUBE_API_BURST:-}" || -n "${DEPLOYMENT_CHAINS_THREADS_PER_CONTROLLER:-}" ]]; then
+            chains_qbt_enabled=true
+        fi
+
+        if [[ "$chains_ha_enabled" == false && "$chains_qbt_enabled" == false ]]; then
+            echo "Chains signing test-standard"
+            return
+        elif [[ "$chains_ha_enabled" == true && "$chains_qbt_enabled" == false ]]; then
+            echo "Chains signing test-ha"
+            return
+        elif [[ "$chains_ha_enabled" == false && "$chains_qbt_enabled" == true ]]; then
+            echo "Chains signing test-qbt"
+            return
+        elif [[ "$chains_ha_enabled" == true && "$chains_qbt_enabled" == true ]]; then
+            echo "Chains signing test-ha_qbt"
+            return
+        fi
     fi
 
     local ha_replicas="${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-0}"

--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -22,9 +22,8 @@ horreum_test_name() {
     fi
 
     if [[ "${TEST_SCENARIO:-}" == *signing* ]]; then
-        local chains_ha_replicas="${DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS:-0}"
         local chains_ha_enabled=false
-        if [[ -n "${DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS:-}" && "${chains_ha_replicas}" != "0" ]]; then
+        if [[ "${DEPLOYMENT_CHAINS_CONTROLLER_HA_REPLICAS:-0}" != "0" ]]; then
             chains_ha_enabled=true
         fi
 
@@ -32,20 +31,16 @@ horreum_test_name() {
         if [[ -n "${DEPLOYMENT_CHAINS_KUBE_API_QPS:-}" || -n "${DEPLOYMENT_CHAINS_KUBE_API_BURST:-}" || -n "${DEPLOYMENT_CHAINS_THREADS_PER_CONTROLLER:-}" ]]; then
             chains_qbt_enabled=true
         fi
-
-        if [[ "$chains_ha_enabled" == false && "$chains_qbt_enabled" == false ]]; then
-            echo "Chains signing test-standard"
-            return
+        local suffix="standard"
+        if [[ "$chains_ha_enabled" == true && "$chains_qbt_enabled" == true ]]; then
+            suffix="ha_qbt"
         elif [[ "$chains_ha_enabled" == true && "$chains_qbt_enabled" == false ]]; then
-            echo "Chains signing test-ha"
-            return
+            suffix="ha"
         elif [[ "$chains_ha_enabled" == false && "$chains_qbt_enabled" == true ]]; then
-            echo "Chains signing test-qbt"
-            return
-        elif [[ "$chains_ha_enabled" == true && "$chains_qbt_enabled" == true ]]; then
-            echo "Chains signing test-ha_qbt"
-            return
+            suffix="qbt"
         fi
+        echo "Chains signing test-${sufix}"
+        return
     fi
 
     local ha_replicas="${DEPLOYMENT_PIPELINES_CONTROLLER_HA_REPLICAS:-0}"


### PR DESCRIPTION
## Summary

- Created per-scenario Horreum YAML configs for Chains signing test under `tools/horreum/horreum_chains/`, splitting the single "OpenShift Pipelines Chains signing test" into 4 scenario-specific tests:
  - `Chains signing test-standard` (ha=false, qbt=false)
  - `Chains signing test-qbt` (ha=false, qbt=true)
  - `Chains signing test-ha` (ha=true, qbt=false)
  - `Chains signing test-ha_qbt` (ha=true, qbt=true)
- `signing_throughput` group from original config split into `signing_duration` (fixedThreshold max) and `signing_throughput` (fixedThreshold min), since duration and throughput require opposite threshold directions
- All other metrics use fixedThreshold max (CPU, memory, workqueue, etcd, cluster CPU, signing duration) except `PipelineRuns_Succeeded_count`, `TaskRuns_Succeeded_count`, and `signing_count` which use fixedThreshold min
- Updated `horreum_test_name()` in `tools/stats.sh` to route signing scenarios to the correct per-scenario test based on Chains HA/QBT env vars
