### PR TITLE
Fix typo in Chains Horreum test name: sufix → suffix

### DIFF
--- a/tools/stats.sh
+++ b/tools/stats.sh
@@ -39,7 +39,7 @@ horreum_test_name() {
         elif [[ "$chains_ha_enabled" == false && "$chains_qbt_enabled" == true ]]; then
             suffix="qbt"
         fi
-        echo "Chains signing test-${sufix}"
+        echo "Chains signing test-${suffix}"
         return
     fi
 


### PR DESCRIPTION
The misspelled variable caused all Chains variants to get .name = "Chains signing test-" (empty suffix), preventing routing to the correct variant-specific Horreum tests.