### PR TITLE
Add variant-specific bar chart dashboards and Results dashboards for Grafana

### DIFF
--- a/config/grafonnet-workdir/build.sh
+++ b/config/grafonnet-workdir/build.sh
@@ -17,3 +17,10 @@ build src/pipelines-dashboard.jsonnet generated/pipelines-dashboard.json
 build src/pipelines-comparison-dashboard.jsonnet generated/pipelines-comparison-dashboard.json
 build src/chains-dashboard.jsonnet generated/chains-dashboard.json
 build src/chains-comparison-dashboard.jsonnet generated/chains-comparison-dashboard.json
+
+# v2 dashboards (new per-variant test IDs)
+build src/pipelines-version-comparison-v2.jsonnet generated/pipelines-version-comparison-v2.json
+build src/chains-version-comparison-v2.jsonnet generated/chains-version-comparison-v2.json
+build src/results-dashboard.jsonnet generated/results-dashboard.json
+build src/results-comparison-dashboard.jsonnet generated/results-comparison-dashboard.json
+build src/results-version-comparison-v2.jsonnet generated/results-version-comparison-v2.json

--- a/config/grafonnet-workdir/generated/chains-comparison-dashboard.json
+++ b/config/grafonnet-workdir/generated/chains-comparison-dashboard.json
@@ -1,7 +1,7 @@
 {
-  "description": "Side-by-side comparison of Chains signing performance metrics across different released versions. Select two non-nightly versions to compare.",
+  "description": "Side-by-side comparison of two versions for the same variant. Select a variant, pick two versions, and see their Chains signing metrics mirrored left/right. Includes historical data from legacy test 418.",
   "editable": true,
-  "graphTooltip": 1,
+  "graphTooltip": 2,
   "panels": [
     {
       "gridPos": {
@@ -24,8 +24,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -40,15 +42,26 @@
         "y": 1
       },
       "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_throughput')::DOUBLE PRECISION) AS pr_throughput\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_throughput @ ' || test_total AS metric,\n  pr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_throughput')::DOUBLE PRECISION) AS pr_throughput\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_throughput @ t' || test_total AS metric,\n  pr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Signing Throughput - v${version1}",
+      "title": "PipelineRun Signing Throughput — ${version1}",
       "type": "timeseries"
     },
     {
@@ -61,8 +74,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -77,15 +92,26 @@
         "y": 1
       },
       "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_throughput')::DOUBLE PRECISION) AS pr_throughput\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_throughput @ ' || test_total AS metric,\n  pr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_throughput')::DOUBLE PRECISION) AS pr_throughput\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_throughput @ t' || test_total AS metric,\n  pr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Signing Throughput - v${version2}",
+      "title": "PipelineRun Signing Throughput — ${version2}",
       "type": "timeseries"
     },
     {
@@ -98,8 +124,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -114,15 +142,26 @@
         "y": 9
       },
       "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_throughput')::DOUBLE PRECISION) AS tr_throughput\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_throughput @ ' || test_total AS metric,\n  tr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_throughput')::DOUBLE PRECISION) AS tr_throughput\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_throughput @ t' || test_total AS metric,\n  tr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Signing Throughput - v${version1}",
+      "title": "TaskRun Signing Throughput — ${version1}",
       "type": "timeseries"
     },
     {
@@ -135,8 +174,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -151,15 +192,26 @@
         "y": 9
       },
       "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_throughput')::DOUBLE PRECISION) AS tr_throughput\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_throughput @ ' || test_total AS metric,\n  tr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_throughput')::DOUBLE PRECISION) AS tr_throughput\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_throughput @ t' || test_total AS metric,\n  tr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Signing Throughput - v${version2}",
+      "title": "TaskRun Signing Throughput — ${version2}",
       "type": "timeseries"
     },
     {
@@ -172,8 +224,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -188,15 +242,26 @@
         "y": 17
       },
       "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_duration')::DOUBLE PRECISION) AS pr_sign_duration\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_duration @ ' || test_total AS metric,\n  pr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_duration')::DOUBLE PRECISION) AS pr_sign_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_duration @ t' || test_total AS metric,\n  pr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Signing Duration - v${version1}",
+      "title": "PipelineRun Signing Duration — ${version1}",
       "type": "timeseries"
     },
     {
@@ -209,8 +274,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -225,15 +292,26 @@
         "y": 17
       },
       "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_duration')::DOUBLE PRECISION) AS pr_sign_duration\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_duration @ ' || test_total AS metric,\n  pr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_duration')::DOUBLE PRECISION) AS pr_sign_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_duration @ t' || test_total AS metric,\n  pr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Signing Duration - v${version2}",
+      "title": "PipelineRun Signing Duration — ${version2}",
       "type": "timeseries"
     },
     {
@@ -246,8 +324,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -262,15 +342,26 @@
         "y": 25
       },
       "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_duration')::DOUBLE PRECISION) AS tr_sign_duration\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_duration @ ' || test_total AS metric,\n  tr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_duration')::DOUBLE PRECISION) AS tr_sign_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_duration @ t' || test_total AS metric,\n  tr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Signing Duration - v${version1}",
+      "title": "TaskRun Signing Duration — ${version1}",
       "type": "timeseries"
     },
     {
@@ -283,8 +374,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -299,15 +392,26 @@
         "y": 25
       },
       "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_duration')::DOUBLE PRECISION) AS tr_sign_duration\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_duration @ ' || test_total AS metric,\n  tr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_duration')::DOUBLE PRECISION) AS tr_sign_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_duration @ t' || test_total AS metric,\n  tr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Signing Duration - v${version2}",
+      "title": "TaskRun Signing Duration — ${version2}",
       "type": "timeseries"
     },
     {
@@ -320,8 +424,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -336,15 +442,26 @@
         "y": 33
       },
       "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_false')::DOUBLE PRECISION) AS pr_sign_failed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_true')::DOUBLE PRECISION) AS pr_signed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_unsigned')::DOUBLE PRECISION) AS pr_unsigned\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_false'\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_true'\n    AND label_values ? '__results_PipelineRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_failed @ ' || test_total AS metric,\n  pr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_signed @ ' || test_total AS metric,\n  pr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_unsigned @ ' || test_total AS metric,\n  pr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_false')::DOUBLE PRECISION) AS pr_sign_failed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_true')::DOUBLE PRECISION) AS pr_signed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_unsigned')::DOUBLE PRECISION) AS pr_unsigned\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_false'\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_true'\n    AND label_values ? '__results_PipelineRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_failed @ t' || test_total AS metric,\n  pr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_signed @ t' || test_total AS metric,\n  pr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_unsigned @ t' || test_total AS metric,\n  pr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Signed Count - v${version1}",
+      "title": "PipelineRun Signed Count — ${version1}",
       "type": "timeseries"
     },
     {
@@ -357,8 +474,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -373,15 +492,26 @@
         "y": 33
       },
       "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_false')::DOUBLE PRECISION) AS pr_sign_failed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_true')::DOUBLE PRECISION) AS pr_signed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_unsigned')::DOUBLE PRECISION) AS pr_unsigned\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_false'\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_true'\n    AND label_values ? '__results_PipelineRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_failed @ ' || test_total AS metric,\n  pr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_signed @ ' || test_total AS metric,\n  pr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_unsigned @ ' || test_total AS metric,\n  pr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_false')::DOUBLE PRECISION) AS pr_sign_failed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_true')::DOUBLE PRECISION) AS pr_signed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_unsigned')::DOUBLE PRECISION) AS pr_unsigned\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_false'\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_true'\n    AND label_values ? '__results_PipelineRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_failed @ t' || test_total AS metric,\n  pr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_signed @ t' || test_total AS metric,\n  pr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_unsigned @ t' || test_total AS metric,\n  pr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Signed Count - v${version2}",
+      "title": "PipelineRun Signed Count — ${version2}",
       "type": "timeseries"
     },
     {
@@ -394,8 +524,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -410,15 +542,26 @@
         "y": 41
       },
       "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_false')::DOUBLE PRECISION) AS tr_sign_failed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_true')::DOUBLE PRECISION) AS tr_signed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_unsigned')::DOUBLE PRECISION) AS tr_unsigned\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_signing_count_signed_false'\n    AND label_values ? '__results_TaskRuns_signing_count_signed_true'\n    AND label_values ? '__results_TaskRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_failed @ ' || test_total AS metric,\n  tr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_signed @ ' || test_total AS metric,\n  tr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_unsigned @ ' || test_total AS metric,\n  tr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_false')::DOUBLE PRECISION) AS tr_sign_failed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_true')::DOUBLE PRECISION) AS tr_signed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_unsigned')::DOUBLE PRECISION) AS tr_unsigned\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_signing_count_signed_false'\n    AND label_values ? '__results_TaskRuns_signing_count_signed_true'\n    AND label_values ? '__results_TaskRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_failed @ t' || test_total AS metric,\n  tr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_signed @ t' || test_total AS metric,\n  tr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_unsigned @ t' || test_total AS metric,\n  tr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Signed Count - v${version1}",
+      "title": "TaskRun Signed Count — ${version1}",
       "type": "timeseries"
     },
     {
@@ -431,8 +574,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -447,15 +592,26 @@
         "y": 41
       },
       "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_false')::DOUBLE PRECISION) AS tr_sign_failed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_true')::DOUBLE PRECISION) AS tr_signed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_unsigned')::DOUBLE PRECISION) AS tr_unsigned\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_signing_count_signed_false'\n    AND label_values ? '__results_TaskRuns_signing_count_signed_true'\n    AND label_values ? '__results_TaskRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_failed @ ' || test_total AS metric,\n  tr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_signed @ ' || test_total AS metric,\n  tr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_unsigned @ ' || test_total AS metric,\n  tr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_false')::DOUBLE PRECISION) AS tr_sign_failed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_true')::DOUBLE PRECISION) AS tr_signed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_unsigned')::DOUBLE PRECISION) AS tr_unsigned\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_signing_count_signed_false'\n    AND label_values ? '__results_TaskRuns_signing_count_signed_true'\n    AND label_values ? '__results_TaskRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_failed @ t' || test_total AS metric,\n  tr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_signed @ t' || test_total AS metric,\n  tr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_unsigned @ t' || test_total AS metric,\n  tr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Signed Count - v${version2}",
+      "title": "TaskRun Signed Count — ${version2}",
       "type": "timeseries"
     },
     {
@@ -479,8 +635,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -495,15 +653,26 @@
         "y": 50
       },
       "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ ' || test_total AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ t' || test_total AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Succeeded - v${version1}",
+      "title": "PipelineRun Succeeded — ${version1}",
       "type": "timeseries"
     },
     {
@@ -516,8 +685,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -532,15 +703,26 @@
         "y": 50
       },
       "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ ' || test_total AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ t' || test_total AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Succeeded - v${version2}",
+      "title": "PipelineRun Succeeded — ${version2}",
       "type": "timeseries"
     },
     {
@@ -548,13 +730,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total PipelineRuns that failed. Should be 0.",
+      "description": "Failed PipelineRuns. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -569,15 +754,26 @@
         "y": 58
       },
       "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ ' || test_total AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ t' || test_total AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Failed - v${version1}",
+      "title": "PipelineRun Failed — ${version1}",
       "type": "timeseries"
     },
     {
@@ -585,13 +781,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total PipelineRuns that failed. Should be 0.",
+      "description": "Failed PipelineRuns. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -606,15 +805,26 @@
         "y": 58
       },
       "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ ' || test_total AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ t' || test_total AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Failed - v${version2}",
+      "title": "PipelineRun Failed — ${version2}",
       "type": "timeseries"
     },
     {
@@ -627,8 +837,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -643,15 +855,26 @@
         "y": 66
       },
       "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ ' || test_total AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ t' || test_total AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Succeeded - v${version1}",
+      "title": "TaskRun Succeeded — ${version1}",
       "type": "timeseries"
     },
     {
@@ -664,8 +887,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -680,15 +905,26 @@
         "y": 66
       },
       "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ ' || test_total AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ t' || test_total AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Succeeded - v${version2}",
+      "title": "TaskRun Succeeded — ${version2}",
       "type": "timeseries"
     },
     {
@@ -696,13 +932,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total TaskRuns that failed. Should be 0.",
+      "description": "Failed TaskRuns. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -717,15 +956,26 @@
         "y": 74
       },
       "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ ' || test_total AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ t' || test_total AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Failed - v${version1}",
+      "title": "TaskRun Failed — ${version1}",
       "type": "timeseries"
     },
     {
@@ -733,13 +983,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total TaskRuns that failed. Should be 0.",
+      "description": "Failed TaskRuns. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -754,15 +1007,26 @@
         "y": 74
       },
       "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ ' || test_total AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ t' || test_total AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Failed - v${version2}",
+      "title": "TaskRun Failed — ${version2}",
       "type": "timeseries"
     },
     {
@@ -786,8 +1050,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -802,15 +1068,26 @@
         "y": 83
       },
       "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonChainsController_cpu_max'\n    AND label_values ? '__measurements_tektonChainsController_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max @ ' || test_total AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean @ ' || test_total AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonChainsController_cpu_max'\n    AND label_values ? '__measurements_tektonChainsController_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max @ t' || test_total AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean @ t' || test_total AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Chains Controller CPU Usage - v${version1}",
+      "title": "Chains Controller CPU Usage — ${version1}",
       "type": "timeseries"
     },
     {
@@ -823,8 +1100,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -839,15 +1118,26 @@
         "y": 83
       },
       "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonChainsController_cpu_max'\n    AND label_values ? '__measurements_tektonChainsController_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max @ ' || test_total AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean @ ' || test_total AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonChainsController_cpu_max'\n    AND label_values ? '__measurements_tektonChainsController_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max @ t' || test_total AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean @ t' || test_total AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Chains Controller CPU Usage - v${version2}",
+      "title": "Chains Controller CPU Usage — ${version2}",
       "type": "timeseries"
     },
     {
@@ -860,8 +1150,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -876,15 +1168,26 @@
         "y": 91
       },
       "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonChainsController_memory_max'\n    AND label_values ? '__measurements_tektonChainsController_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max @ ' || test_total AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean @ ' || test_total AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonChainsController_memory_max'\n    AND label_values ? '__measurements_tektonChainsController_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max @ t' || test_total AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean @ t' || test_total AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Chains Controller Memory Usage - v${version1}",
+      "title": "Chains Controller Memory Usage — ${version1}",
       "type": "timeseries"
     },
     {
@@ -897,8 +1200,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -913,15 +1218,26 @@
         "y": 91
       },
       "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonChainsController_memory_max'\n    AND label_values ? '__measurements_tektonChainsController_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max @ ' || test_total AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean @ ' || test_total AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonChainsController_memory_max'\n    AND label_values ? '__measurements_tektonChainsController_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max @ t' || test_total AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean @ t' || test_total AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Chains Controller Memory Usage - v${version2}",
+      "title": "Chains Controller Memory Usage — ${version2}",
       "type": "timeseries"
     },
     {
@@ -934,8 +1250,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -950,15 +1268,26 @@
         "y": 99
       },
       "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_max')::DOUBLE PRECISION) AS wq_max,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS wq_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_max'\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_max @ ' || test_total AS metric,\n  wq_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_mean @ ' || test_total AS metric,\n  wq_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_max')::DOUBLE PRECISION) AS wq_max,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS wq_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_max'\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_max @ t' || test_total AS metric,\n  wq_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_mean @ t' || test_total AS metric,\n  wq_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Chains Controller Workqueue Depth - v${version1}",
+      "title": "Chains Controller Workqueue Depth — ${version1}",
       "type": "timeseries"
     },
     {
@@ -971,8 +1300,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -987,15 +1318,26 @@
         "y": 99
       },
       "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_max')::DOUBLE PRECISION) AS wq_max,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS wq_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_max'\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_max @ ' || test_total AS metric,\n  wq_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_mean @ ' || test_total AS metric,\n  wq_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_max')::DOUBLE PRECISION) AS wq_max,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS wq_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_max'\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_max @ t' || test_total AS metric,\n  wq_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_mean @ t' || test_total AS metric,\n  wq_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Chains Controller Workqueue Depth - v${version2}",
+      "title": "Chains Controller Workqueue Depth — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1003,13 +1345,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Number of Chains controller Pod restarts. Should be 0.",
+      "description": "Chains controller Pod restarts. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1024,15 +1369,26 @@
         "y": 107
       },
       "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_restarts_range')::DOUBLE PRECISION) AS chains_restarts\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonChainsController_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'chains_restarts @ ' || test_total AS metric,\n  chains_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_restarts_range')::DOUBLE PRECISION) AS chains_restarts\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonChainsController_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'chains_restarts @ t' || test_total AS metric,\n  chains_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Chains Controller Restarts - v${version1}",
+      "title": "Chains Controller Restarts — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1040,13 +1396,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Number of Chains controller Pod restarts. Should be 0.",
+      "description": "Chains controller Pod restarts. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1061,15 +1420,26 @@
         "y": 107
       },
       "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_restarts_range')::DOUBLE PRECISION) AS chains_restarts\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonChainsController_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'chains_restarts @ ' || test_total AS metric,\n  chains_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_restarts_range')::DOUBLE PRECISION) AS chains_restarts\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonChainsController_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'chains_restarts @ t' || test_total AS metric,\n  chains_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Chains Controller Restarts - v${version2}",
+      "title": "Chains Controller Restarts — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1093,8 +1463,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1109,15 +1481,26 @@
         "y": 116
       },
       "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ ' || test_total AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ t' || test_total AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Cluster CPU Usage - v${version1}",
+      "title": "Cluster CPU Usage — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1130,8 +1513,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1146,15 +1531,26 @@
         "y": 116
       },
       "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ ' || test_total AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ t' || test_total AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Cluster CPU Usage - v${version2}",
+      "title": "Cluster CPU Usage — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1167,8 +1563,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1183,15 +1581,26 @@
         "y": 124
       },
       "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ ' || test_total AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ t' || test_total AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Cluster Memory Usage - v${version1}",
+      "title": "Cluster Memory Usage — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1204,8 +1613,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1220,15 +1631,26 @@
         "y": 124
       },
       "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ ' || test_total AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ t' || test_total AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Cluster Memory Usage - v${version2}",
+      "title": "Cluster Memory Usage — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1236,13 +1658,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean CPU usage of API servers.\n- **apiserver_cpu**: openshift-apiserver\n- **kube_apiserver_cpu**: kube-apiserver",
+      "description": "Mean CPU usage of API servers.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1257,15 +1681,26 @@
         "y": 132
       },
       "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS apiserver_cpu,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_cpu @ ' || test_total AS metric,\n  apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ ' || test_total AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS ocp_apiserver_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ t' || test_total AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_cpu @ t' || test_total AS metric,\n  ocp_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "API Server CPU Usage (Mean) - v${version1}",
+      "title": "API Server CPU (OpenShift / Kube) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1273,13 +1708,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean CPU usage of API servers.\n- **apiserver_cpu**: openshift-apiserver\n- **kube_apiserver_cpu**: kube-apiserver",
+      "description": "Mean CPU usage of API servers.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1294,15 +1731,26 @@
         "y": 132
       },
       "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS apiserver_cpu,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_cpu @ ' || test_total AS metric,\n  apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ ' || test_total AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS ocp_apiserver_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ t' || test_total AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_cpu @ t' || test_total AS metric,\n  ocp_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "API Server CPU Usage (Mean) - v${version2}",
+      "title": "API Server CPU (OpenShift / Kube) — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1315,8 +1763,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1331,15 +1781,26 @@
         "y": 140
       },
       "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS apiserver_mem,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_memory_mean'\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_mem @ ' || test_total AS metric,\n  apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ ' || test_total AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS ocp_apiserver_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n    AND label_values ? '__measurements_apiserver_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ t' || test_total AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_mem @ t' || test_total AS metric,\n  ocp_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "API Server Memory Usage (Mean) - v${version1}",
+      "title": "API Server Memory (OpenShift / Kube) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1352,8 +1813,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1368,15 +1831,26 @@
         "y": 140
       },
       "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS apiserver_mem,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_memory_mean'\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_mem @ ' || test_total AS metric,\n  apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ ' || test_total AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS ocp_apiserver_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n    AND label_values ? '__measurements_apiserver_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ t' || test_total AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_mem @ t' || test_total AS metric,\n  ocp_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "API Server Memory Usage (Mean) - v${version2}",
+      "title": "API Server Memory (OpenShift / Kube) — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1400,8 +1874,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1416,15 +1892,26 @@
         "y": 149
       },
       "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ ' || test_total AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ ' || test_total AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ t' || test_total AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ t' || test_total AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd MVCC DB Size (Mean) - v${version1}",
+      "title": "etcd DB Size (total / in-use) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1437,8 +1924,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1453,15 +1942,26 @@
         "y": 149
       },
       "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ ' || test_total AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ ' || test_total AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ t' || test_total AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ t' || test_total AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd MVCC DB Size (Mean) - v${version2}",
+      "title": "etcd DB Size (total / in-use) — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1469,13 +1969,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean and peak etcd request durations.\n- **req_duration_mean**: average latency\n- **req_duration_max**: worst-case latency",
+      "description": "etcd request latency.\n- **req_duration_mean**: average\n- **req_duration_max**: worst-case peak",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1490,15 +1992,26 @@
         "y": 157
       },
       "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ ' || test_total AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ ' || test_total AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ t' || test_total AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ t' || test_total AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd Request Duration - v${version1}",
+      "title": "etcd Request Duration (mean / max) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1506,13 +2019,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean and peak etcd request durations.\n- **req_duration_mean**: average latency\n- **req_duration_max**: worst-case latency",
+      "description": "etcd request latency.\n- **req_duration_mean**: average\n- **req_duration_max**: worst-case peak",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1527,15 +2042,26 @@
         "y": 157
       },
       "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ ' || test_total AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ ' || test_total AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ t' || test_total AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ t' || test_total AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd Request Duration - v${version2}",
+      "title": "etcd Request Duration (mean / max) — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1558,9 +2084,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1575,15 +2104,26 @@
         "y": 166
       },
       "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_restarts_range')::DOUBLE PRECISION) AS apiserver,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd,\n    AVG((label_values->>'__measurements_kubeApiserver_restarts_range')::DOUBLE PRECISION) AS kube_apiserver\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_restarts_range'\n    AND label_values ? '__measurements_etcd_restarts_range'\n    AND label_values ? '__measurements_kubeApiserver_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver @ ' || test_total AS metric,\n  apiserver AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd @ ' || test_total AS metric,\n  etcd AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver @ ' || test_total AS metric,\n  kube_apiserver AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_restarts_range')::DOUBLE PRECISION) AS apiserver,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd,\n    AVG((label_values->>'__measurements_kubeApiserver_restarts_range')::DOUBLE PRECISION) AS kube_apiserver\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_apiserver_restarts_range'\n    AND label_values ? '__measurements_etcd_restarts_range'\n    AND label_values ? '__measurements_kubeApiserver_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver @ t' || test_total AS metric,\n  apiserver AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd @ t' || test_total AS metric,\n  etcd AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver @ t' || test_total AS metric,\n  kube_apiserver AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Infrastructure Restarts - v${version1}",
+      "title": "Infrastructure Restarts — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1595,9 +2135,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1612,15 +2155,26 @@
         "y": 166
       },
       "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_restarts_range')::DOUBLE PRECISION) AS apiserver,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd,\n    AVG((label_values->>'__measurements_kubeApiserver_restarts_range')::DOUBLE PRECISION) AS kube_apiserver\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_restarts_range'\n    AND label_values ? '__measurements_etcd_restarts_range'\n    AND label_values ? '__measurements_kubeApiserver_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver @ ' || test_total AS metric,\n  apiserver AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd @ ' || test_total AS metric,\n  etcd AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver @ ' || test_total AS metric,\n  kube_apiserver AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_restarts_range')::DOUBLE PRECISION) AS apiserver,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd,\n    AVG((label_values->>'__measurements_kubeApiserver_restarts_range')::DOUBLE PRECISION) AS kube_apiserver\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_apiserver_restarts_range'\n    AND label_values ? '__measurements_etcd_restarts_range'\n    AND label_values ? '__measurements_kubeApiserver_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver @ t' || test_total AS metric,\n  apiserver AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd @ t' || test_total AS metric,\n  etcd AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver @ t' || test_total AS metric,\n  kube_apiserver AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Infrastructure Restarts - v${version2}",
+      "title": "Infrastructure Restarts — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1632,9 +2186,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1649,15 +2206,26 @@
         "y": 174
       },
       "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonPipelinesController_restarts_range')::DOUBLE PRECISION) AS pipelines_ctrl,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_restarts_range')::DOUBLE PRECISION) AS pipelines_webhook,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_restarts_range')::DOUBLE PRECISION) AS proxy_webhook\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonPipelinesController_restarts_range'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_restarts_range'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_ctrl @ ' || test_total AS metric,\n  pipelines_ctrl AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_webhook @ ' || test_total AS metric,\n  pipelines_webhook AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook @ ' || test_total AS metric,\n  proxy_webhook AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonPipelinesController_restarts_range')::DOUBLE PRECISION) AS pipelines_ctrl,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_restarts_range')::DOUBLE PRECISION) AS pipelines_webhook,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_restarts_range')::DOUBLE PRECISION) AS proxy_webhook\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_restarts_range'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_restarts_range'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_ctrl @ t' || test_total AS metric,\n  pipelines_ctrl AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_webhook @ t' || test_total AS metric,\n  pipelines_webhook AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook @ t' || test_total AS metric,\n  proxy_webhook AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Tekton Component Restarts - v${version1}",
+      "title": "Tekton Component Restarts — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1669,9 +2237,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1686,15 +2257,26 @@
         "y": 174
       },
       "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonPipelinesController_restarts_range')::DOUBLE PRECISION) AS pipelines_ctrl,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_restarts_range')::DOUBLE PRECISION) AS pipelines_webhook,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_restarts_range')::DOUBLE PRECISION) AS proxy_webhook\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonPipelinesController_restarts_range'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_restarts_range'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_ctrl @ ' || test_total AS metric,\n  pipelines_ctrl AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_webhook @ ' || test_total AS metric,\n  pipelines_webhook AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook @ ' || test_total AS metric,\n  proxy_webhook AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonPipelinesController_restarts_range')::DOUBLE PRECISION) AS pipelines_ctrl,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_restarts_range')::DOUBLE PRECISION) AS pipelines_webhook,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_restarts_range')::DOUBLE PRECISION) AS proxy_webhook\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_restarts_range'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_restarts_range'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_ctrl @ t' || test_total AS metric,\n  pipelines_ctrl AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_webhook @ t' || test_total AS metric,\n  pipelines_webhook AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook @ t' || test_total AS metric,\n  proxy_webhook AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Tekton Component Restarts - v${version2}",
+      "title": "Tekton Component Restarts — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1706,9 +2288,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1723,15 +2308,26 @@
         "y": 182
       },
       "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ ' || test_total AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ t' || test_total AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Scheduler Pending Pods - v${version1}",
+      "title": "Scheduler Pending Pods — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1743,9 +2339,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1760,20 +2359,36 @@
         "y": 182
       },
       "id": 52,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ ' || test_total AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ t' || test_total AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Scheduler Pending Pods - v${version2}",
+      "title": "Scheduler Pending Pods — ${version2}",
       "type": "timeseries"
     }
   ],
   "refresh": "5m",
   "schemaVersion": 39,
+  "tags": [
+    "chains",
+    "comparison",
+    "performance"
+  ],
   "templating": {
     "list": [
       {
@@ -1792,74 +2407,74 @@
       {
         "current": {
           "text": "Standard",
-          "value": "standard"
+          "value": "427"
         },
-        "description": "Standard, HA, QBT, or HA+QBT.",
+        "description": "Chains deployment variant (each maps to a separate Horreum test ID).",
         "includeAll": false,
-        "label": "Deployment Configuration",
+        "label": "Variant",
         "multi": false,
-        "name": "deploy_config",
+        "name": "variant",
         "options": [
           {
             "selected": true,
             "text": "Standard",
-            "value": "standard"
+            "value": "427"
           },
           {
             "selected": false,
             "text": "HA",
-            "value": "ha"
+            "value": "428"
           },
           {
             "selected": false,
             "text": "QBT (non-HA)",
-            "value": "qbt"
+            "value": "429"
           },
           {
             "selected": false,
             "text": "HA + QBT",
-            "value": "ha-qbt"
+            "value": "430"
           }
         ],
-        "query": "Standard : standard,HA : ha,QBT (non-HA) : qbt,HA + QBT : ha-qbt",
+        "query": "Standard : 427,HA : 428,QBT (non-HA) : 429,HA + QBT : 430",
         "type": "custom"
       },
       {
         "current": {
-          "text": "1.22",
-          "value": "1.22"
+          "text": "nightly",
+          "value": "nightly"
         },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "${datasource}"
         },
-        "description": "Version 1 for comparison",
+        "description": "Version 1 for comparison.",
         "includeAll": false,
         "label": "Version 1",
         "multi": false,
         "name": "version1",
-        "query": "SELECT DISTINCT (label_values->>'__deployment_version') AS __text FROM data WHERE horreum_testid = 418 AND label_values ? '__deployment_version' AND (label_values->>'__deployment_version') IS NOT NULL AND (label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = false) AND label_values ? '__results_PipelineRuns_signing_throughput' ORDER BY __text",
-        "refresh": 1,
-        "sort": 4,
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
         "type": "query"
       },
       {
         "current": {
-          "text": "1.21",
-          "value": "1.21"
+          "text": "1.23",
+          "value": "1.23"
         },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "${datasource}"
         },
-        "description": "Version 2 for comparison",
+        "description": "Version 2 for comparison.",
         "includeAll": false,
         "label": "Version 2",
         "multi": false,
         "name": "version2",
-        "query": "SELECT DISTINCT (label_values->>'__deployment_version') AS __text FROM data WHERE horreum_testid = 418 AND label_values ? '__deployment_version' AND (label_values->>'__deployment_version') IS NOT NULL AND (label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = false) AND label_values ? '__results_PipelineRuns_signing_throughput' ORDER BY __text",
-        "refresh": 1,
-        "sort": 4,
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
         "type": "query"
       },
       {
@@ -1871,12 +2486,12 @@
           "type": "grafana-postgresql-datasource",
           "uid": "${datasource}"
         },
-        "description": "Filter by total PipelineRuns count (500, 1000, 1500).",
+        "description": "Filter by total PipelineRuns count (500, 1000).",
         "includeAll": true,
         "label": "Test Total",
         "multi": true,
         "name": "test_total",
-        "query": "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE horreum_testid = 418 AND label_values ? '__parameters_test_total' ORDER BY test_total",
+        "query": "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__parameters_test_total' ORDER BY test_total",
         "refresh": 2,
         "sort": 3,
         "type": "query"
@@ -1884,10 +2499,10 @@
     ]
   },
   "time": {
-    "from": "now-14d",
+    "from": "now-30d",
     "to": "now"
   },
   "timezone": "utc",
-  "title": "Chains Signing Performance Comparison Dashboard",
+  "title": "Chains Signing Performance Comparison",
   "uid": "Chains_Signing_Performance_Comparison"
 }

--- a/config/grafonnet-workdir/generated/chains-dashboard.json
+++ b/config/grafonnet-workdir/generated/chains-dashboard.json
@@ -1,7 +1,7 @@
 {
-  "description": "OpenShift Pipelines Chains signing performance. Tracks signing throughput, duration, Chains controller resources, and cluster health across different test_total values (500, 1000, 1500).",
+  "description": "OpenShift Pipelines Chains signing performance trends per variant and version. Includes historical data from legacy test 418 and new per-variant tests (427-430). Select a variant, version, and test total to track regressions over time.",
   "editable": true,
-  "graphTooltip": 1,
+  "graphTooltip": 2,
   "panels": [
     {
       "gridPos": {
@@ -24,8 +24,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -40,11 +42,22 @@
         "y": 1
       },
       "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_throughput')::DOUBLE PRECISION) AS pr_throughput\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_PipelineRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_throughput @ ' || test_total AS metric,\n  pr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_throughput')::DOUBLE PRECISION) AS pr_throughput\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_throughput @ t' || test_total AS metric,\n  pr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -56,13 +69,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "TaskRun signing throughput (signed runs per second). Higher is better. Computed as signed_count / signing_window_duration.",
+      "description": "TaskRun signing throughput (signed runs per second). Higher is better.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -77,11 +92,22 @@
         "y": 1
       },
       "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_throughput')::DOUBLE PRECISION) AS tr_throughput\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_TaskRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_throughput @ ' || test_total AS metric,\n  tr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_throughput')::DOUBLE PRECISION) AS tr_throughput\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_signing_throughput'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_throughput @ t' || test_total AS metric,\n  tr_throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -93,13 +119,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total wall-clock time of the PipelineRun signing window (last signed_at - first signed_at). Lower is better — indicates how quickly Chains processes the entire batch.",
+      "description": "Total wall-clock time of the PipelineRun signing window (last signed_at - first signed_at). Lower is better.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -114,11 +142,22 @@
         "y": 9
       },
       "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_duration')::DOUBLE PRECISION) AS pr_sign_duration\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_PipelineRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_duration @ ' || test_total AS metric,\n  pr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_duration')::DOUBLE PRECISION) AS pr_sign_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_duration @ t' || test_total AS metric,\n  pr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -130,13 +169,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total wall-clock time of the TaskRun signing window (last signed_at - first signed_at). Lower is better.",
+      "description": "Total wall-clock time of the TaskRun signing window. Lower is better.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -151,11 +192,22 @@
         "y": 9
       },
       "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_duration')::DOUBLE PRECISION) AS tr_sign_duration\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_TaskRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_duration @ ' || test_total AS metric,\n  tr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_duration')::DOUBLE PRECISION) AS tr_sign_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_signing_duration'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_duration @ t' || test_total AS metric,\n  tr_sign_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -172,8 +224,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -188,11 +242,22 @@
         "y": 17
       },
       "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_false')::DOUBLE PRECISION) AS pr_sign_failed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_true')::DOUBLE PRECISION) AS pr_signed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_unsigned')::DOUBLE PRECISION) AS pr_unsigned\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_false'\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_true'\n    AND label_values ? '__results_PipelineRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_failed @ ' || test_total AS metric,\n  pr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_signed @ ' || test_total AS metric,\n  pr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_unsigned @ ' || test_total AS metric,\n  pr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_false')::DOUBLE PRECISION) AS pr_sign_failed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_signed_true')::DOUBLE PRECISION) AS pr_signed,\n    AVG((label_values->>'__results_PipelineRuns_signing_count_unsigned')::DOUBLE PRECISION) AS pr_unsigned\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_false'\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_true'\n    AND label_values ? '__results_PipelineRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_sign_failed @ t' || test_total AS metric,\n  pr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_signed @ t' || test_total AS metric,\n  pr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_unsigned @ t' || test_total AS metric,\n  pr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -204,13 +269,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "TaskRun signing outcome breakdown:\n- **tr_signed**: successfully signed\n- **tr_unsigned**: never signed (still pending)\n- **tr_sign_failed**: signing attempted but failed",
+      "description": "TaskRun signing outcome breakdown:\n- **tr_signed**: successfully signed\n- **tr_unsigned**: never signed\n- **tr_sign_failed**: signing failed",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -225,11 +292,22 @@
         "y": 17
       },
       "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_false')::DOUBLE PRECISION) AS tr_sign_failed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_true')::DOUBLE PRECISION) AS tr_signed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_unsigned')::DOUBLE PRECISION) AS tr_unsigned\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_TaskRuns_signing_count_signed_false'\n    AND label_values ? '__results_TaskRuns_signing_count_signed_true'\n    AND label_values ? '__results_TaskRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_failed @ ' || test_total AS metric,\n  tr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_signed @ ' || test_total AS metric,\n  tr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_unsigned @ ' || test_total AS metric,\n  tr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_false')::DOUBLE PRECISION) AS tr_sign_failed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_signed_true')::DOUBLE PRECISION) AS tr_signed,\n    AVG((label_values->>'__results_TaskRuns_signing_count_unsigned')::DOUBLE PRECISION) AS tr_unsigned\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_signing_count_signed_false'\n    AND label_values ? '__results_TaskRuns_signing_count_signed_true'\n    AND label_values ? '__results_TaskRuns_signing_count_unsigned'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_sign_failed @ t' || test_total AS metric,\n  tr_sign_failed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_signed @ t' || test_total AS metric,\n  tr_signed AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_unsigned @ t' || test_total AS metric,\n  tr_unsigned AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -257,8 +335,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -273,11 +353,22 @@
         "y": 26
       },
       "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ ' || test_total AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ t' || test_total AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -293,9 +384,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -310,11 +404,22 @@
         "y": 26
       },
       "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ ' || test_total AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ t' || test_total AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -331,8 +436,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -347,11 +454,22 @@
         "y": 34
       },
       "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ ' || test_total AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ t' || test_total AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -367,9 +485,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -384,11 +505,22 @@
         "y": 34
       },
       "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ ' || test_total AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ t' || test_total AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -411,13 +543,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Tekton Chains controller CPU usage in CPU cores (e.g. 0.5 = 500 millicores).\n- **cpu_mean**: average over the test window\n- **cpu_max**: peak usage\n\nHigh CPU indicates signing is compute-bound (e.g. cryptographic operations).",
+      "description": "Tekton Chains controller CPU usage in CPU cores.\n- **cpu_mean**: average over the test window\n- **cpu_max**: peak usage",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -432,11 +566,22 @@
         "y": 43
       },
       "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_tektonChainsController_cpu_max'\n    AND label_values ? '__measurements_tektonChainsController_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max @ ' || test_total AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean @ ' || test_total AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonChainsController_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonChainsController_cpu_max'\n    AND label_values ? '__measurements_tektonChainsController_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max @ t' || test_total AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean @ t' || test_total AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -448,13 +593,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Tekton Chains controller memory (RSS) usage.\n- **mem_mean**: average over the test window\n- **mem_max**: peak usage\n\nGrowing memory may indicate leaks or large attestation payloads.",
+      "description": "Tekton Chains controller memory (RSS) usage.\n- **mem_mean**: average\n- **mem_max**: peak",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -469,11 +616,22 @@
         "y": 43
       },
       "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_tektonChainsController_memory_max'\n    AND label_values ? '__measurements_tektonChainsController_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max @ ' || test_total AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean @ ' || test_total AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonChainsController_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonChainsController_memory_max'\n    AND label_values ? '__measurements_tektonChainsController_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max @ t' || test_total AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean @ t' || test_total AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -485,13 +643,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Chains controller workqueue depth.\n- **wq_mean**: average queue depth during the test\n- **wq_max**: peak queue depth\n\nA growing workqueue means the controller cannot sign runs fast enough. Sustained high values indicate a bottleneck.",
+      "description": "Chains controller workqueue depth.\n- **wq_mean**: average queue depth\n- **wq_max**: peak queue depth\n\nSustained high values indicate a signing bottleneck.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -506,11 +666,22 @@
         "y": 51
       },
       "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_max')::DOUBLE PRECISION) AS wq_max,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS wq_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_max'\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_max @ ' || test_total AS metric,\n  wq_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_mean @ ' || test_total AS metric,\n  wq_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_max')::DOUBLE PRECISION) AS wq_max,\n    AVG((label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS wq_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_max'\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_max @ t' || test_total AS metric,\n  wq_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'wq_mean @ t' || test_total AS metric,\n  wq_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -522,13 +693,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Number of Chains controller Pod restarts during the test. Should be 0. Restarts during signing cause missed or delayed signatures.",
+      "description": "Chains controller Pod restarts during the test. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -543,11 +717,22 @@
         "y": 51
       },
       "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_restarts_range')::DOUBLE PRECISION) AS chains_restarts\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_tektonChainsController_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'chains_restarts @ ' || test_total AS metric,\n  chains_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonChainsController_restarts_range')::DOUBLE PRECISION) AS chains_restarts\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonChainsController_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'chains_restarts @ t' || test_total AS metric,\n  chains_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -570,13 +755,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean total CPU usage rate across all cluster nodes during the test, in CPU cores.",
+      "description": "Mean total CPU usage rate across all cluster nodes, in CPU cores.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -591,11 +778,22 @@
         "y": 60
       },
       "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ ' || test_total AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ t' || test_total AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -607,13 +805,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean total RSS memory usage across all cluster nodes during the test.",
+      "description": "Mean total RSS memory usage across all cluster nodes.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -628,11 +828,22 @@
         "y": 60
       },
       "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ ' || test_total AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ t' || test_total AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -644,13 +855,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean CPU usage of OpenShift and Kubernetes API servers.\n- **apiserver_cpu**: openshift-apiserver\n- **kube_apiserver_cpu**: kube-apiserver",
+      "description": "Mean CPU usage of the OpenShift and Kubernetes API servers.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -665,15 +878,26 @@
         "y": 68
       },
       "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS apiserver_cpu,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_cpu @ ' || test_total AS metric,\n  apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ ' || test_total AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS ocp_apiserver_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ t' || test_total AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_cpu @ t' || test_total AS metric,\n  ocp_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "API Server CPU Usage (Mean)",
+      "title": "API Server CPU (OpenShift / Kube)",
       "type": "timeseries"
     },
     {
@@ -681,13 +905,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean memory usage of OpenShift and Kubernetes API servers.",
+      "description": "Mean memory usage of the OpenShift and Kubernetes API servers.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -702,15 +928,26 @@
         "y": 68
       },
       "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS apiserver_mem,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_apiserver_memory_mean'\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_mem @ ' || test_total AS metric,\n  apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ ' || test_total AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS ocp_apiserver_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n    AND label_values ? '__measurements_apiserver_memory_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ t' || test_total AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_mem @ t' || test_total AS metric,\n  ocp_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "API Server Memory Usage (Mean)",
+      "title": "API Server Memory (OpenShift / Kube)",
       "type": "timeseries"
     },
     {
@@ -729,13 +966,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean etcd MVCC database size.\n- **db_total**: total allocated size on disk\n- **db_in_use**: logical size of live data\n\nChains stores signing metadata in annotations, which increases etcd load.",
+      "description": "Mean etcd MVCC database size.\n- **db_total**: total allocated size on disk\n- **db_in_use**: live data size\n\nChains stores signing metadata in annotations, which increases etcd load.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -750,15 +989,26 @@
         "y": 77
       },
       "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ ' || test_total AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ ' || test_total AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ t' || test_total AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ t' || test_total AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd MVCC DB Size (Mean)",
+      "title": "etcd DB Size (total / in-use)",
       "type": "timeseries"
     },
     {
@@ -766,13 +1016,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean and peak etcd request duration.\n- **req_duration_mean**: average latency\n- **req_duration_max**: worst-case latency\n\nHigh values indicate etcd pressure from Chains annotation writes.",
+      "description": "Mean and peak etcd request duration.\n- **req_duration_mean**: average latency\n- **req_duration_max**: worst-case latency",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -787,15 +1039,26 @@
         "y": 77
       },
       "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ ' || test_total AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ ' || test_total AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ t' || test_total AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ t' || test_total AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd Request Duration",
+      "title": "etcd Request Duration (mean / max)",
       "type": "timeseries"
     },
     {
@@ -818,9 +1081,12 @@
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -835,11 +1101,22 @@
         "y": 86
       },
       "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_restarts_range')::DOUBLE PRECISION) AS apiserver,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd,\n    AVG((label_values->>'__measurements_kubeApiserver_restarts_range')::DOUBLE PRECISION) AS kube_apiserver\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_apiserver_restarts_range'\n    AND label_values ? '__measurements_etcd_restarts_range'\n    AND label_values ? '__measurements_kubeApiserver_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver @ ' || test_total AS metric,\n  apiserver AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd @ ' || test_total AS metric,\n  etcd AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver @ ' || test_total AS metric,\n  kube_apiserver AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_apiserver_restarts_range')::DOUBLE PRECISION) AS apiserver,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd,\n    AVG((label_values->>'__measurements_kubeApiserver_restarts_range')::DOUBLE PRECISION) AS kube_apiserver\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_apiserver_restarts_range'\n    AND label_values ? '__measurements_etcd_restarts_range'\n    AND label_values ? '__measurements_kubeApiserver_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver @ t' || test_total AS metric,\n  apiserver AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd @ t' || test_total AS metric,\n  etcd AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver @ t' || test_total AS metric,\n  kube_apiserver AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -851,13 +1128,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Restart counts for Tekton Pipelines components. All should be 0.\n\nNote: Chains controller restarts are shown separately in the Chains Controller section above.",
+      "description": "Restart counts for Tekton Pipelines components. All should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -872,11 +1152,22 @@
         "y": 86
       },
       "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonPipelinesController_restarts_range')::DOUBLE PRECISION) AS pipelines_ctrl,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_restarts_range')::DOUBLE PRECISION) AS pipelines_webhook,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_restarts_range')::DOUBLE PRECISION) AS proxy_webhook\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_tektonPipelinesController_restarts_range'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_restarts_range'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_ctrl @ ' || test_total AS metric,\n  pipelines_ctrl AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_webhook @ ' || test_total AS metric,\n  pipelines_webhook AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook @ ' || test_total AS metric,\n  proxy_webhook AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_tektonPipelinesController_restarts_range')::DOUBLE PRECISION) AS pipelines_ctrl,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_restarts_range')::DOUBLE PRECISION) AS pipelines_webhook,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_restarts_range')::DOUBLE PRECISION) AS proxy_webhook\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_restarts_range'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_restarts_range'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_restarts_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_ctrl @ t' || test_total AS metric,\n  pipelines_ctrl AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pipelines_webhook @ t' || test_total AS metric,\n  pipelines_webhook AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook @ t' || test_total AS metric,\n  proxy_webhook AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -888,13 +1179,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Range of pending pods in the kube-scheduler queue. High values indicate scheduling pressure.",
+      "description": "Range of pending pods in the kube-scheduler queue.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -909,11 +1203,22 @@
         "y": 94
       },
       "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE horreum_testid = 418\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (\n  ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)\n  OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')\n)\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ ' || test_total AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_total')::INTEGER AS test_total,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, test_total\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ t' || test_total AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -923,6 +1228,11 @@
   ],
   "refresh": "5m",
   "schemaVersion": 39,
+  "tags": [
+    "chains",
+    "trend",
+    "performance"
+  ],
   "templating": {
     "list": [
       {
@@ -941,36 +1251,36 @@
       {
         "current": {
           "text": "Standard",
-          "value": "standard"
+          "value": "427"
         },
-        "description": "Standard, HA, QBT, or HA+QBT.",
+        "description": "Chains deployment variant (each maps to a separate Horreum test ID).",
         "includeAll": false,
-        "label": "Deployment Configuration",
+        "label": "Variant",
         "multi": false,
-        "name": "deploy_config",
+        "name": "variant",
         "options": [
           {
             "selected": true,
             "text": "Standard",
-            "value": "standard"
+            "value": "427"
           },
           {
             "selected": false,
             "text": "HA",
-            "value": "ha"
+            "value": "428"
           },
           {
             "selected": false,
             "text": "QBT (non-HA)",
-            "value": "qbt"
+            "value": "429"
           },
           {
             "selected": false,
             "text": "HA + QBT",
-            "value": "ha-qbt"
+            "value": "430"
           }
         ],
-        "query": "Standard : standard,HA : ha,QBT (non-HA) : qbt,HA + QBT : ha-qbt",
+        "query": "Standard : 427,HA : 428,QBT (non-HA) : 429,HA + QBT : 430",
         "type": "custom"
       },
       {
@@ -982,14 +1292,14 @@
           "type": "grafana-postgresql-datasource",
           "uid": "${datasource}"
         },
-        "description": "Filter by Pipelines version.",
+        "description": "Filter to a specific version to track its trend over time.",
         "includeAll": false,
         "label": "Version",
         "multi": false,
         "name": "version",
-        "query": "SELECT DISTINCT CASE WHEN (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE (label_values->>'__deployment_version') END AS version FROM data WHERE horreum_testid = 418 AND label_values ? '__deployment_version' AND (label_values->>'__deployment_version') IS NOT NULL AND label_values ? '__results_PipelineRuns_signing_throughput' ORDER BY version",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
         "refresh": 2,
-        "sort": 3,
+        "sort": 0,
         "type": "query"
       },
       {
@@ -1001,12 +1311,12 @@
           "type": "grafana-postgresql-datasource",
           "uid": "${datasource}"
         },
-        "description": "Filter by total PipelineRuns count (500, 1000, 1500).",
+        "description": "Filter by total PipelineRuns count (500, 1000).",
         "includeAll": true,
         "label": "Test Total",
         "multi": true,
         "name": "test_total",
-        "query": "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE horreum_testid = 418 AND label_values ? '__parameters_test_total' ORDER BY test_total",
+        "query": "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__parameters_test_total' ORDER BY test_total",
         "refresh": 2,
         "sort": 3,
         "type": "query"
@@ -1014,7 +1324,7 @@
     ]
   },
   "time": {
-    "from": "now-14d",
+    "from": "now-30d",
     "to": "now"
   },
   "timezone": "utc",

--- a/config/grafonnet-workdir/generated/chains-version-comparison-v2.json
+++ b/config/grafonnet-workdir/generated/chains-version-comparison-v2.json
@@ -1,0 +1,2934 @@
+{
+  "description": "Daily side-by-side version comparison of Chains signing performance. Includes historical data from legacy test 418 and new per-variant tests (427-430).",
+  "editable": true,
+  "graphTooltip": 2,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "title": "Signing Results",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "PipelineRun signing throughput per version per day (signed/sec). Higher is better.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_signing_throughput')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_PipelineRuns_signing_throughput'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Signing Throughput",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "TaskRun signing throughput per version per day (signed/sec). Higher is better.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_signing_throughput')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_TaskRuns_signing_throughput'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Signing Throughput",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total PipelineRun signing window duration per version per day. Lower is better.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 4,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_signing_duration')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_PipelineRuns_signing_duration'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Signing Duration",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total TaskRun signing window duration per version per day. Lower is better.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 5,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_signing_duration')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_TaskRuns_signing_duration'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Signing Duration",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "PipelineRuns signed successfully per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 6,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_signing_count_signed_true')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_PipelineRuns_signing_count_signed_true'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Signed Count",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "PipelineRuns that remained unsigned per version per day. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 7,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_signing_count_unsigned')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_PipelineRuns_signing_count_unsigned'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Unsigned",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "TaskRuns signed successfully per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 8,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_signing_count_signed_true')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_TaskRuns_signing_count_signed_true'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Signed Count",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "TaskRuns that remained unsigned per version per day. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 9,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_signing_count_unsigned')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_TaskRuns_signing_count_unsigned'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Unsigned",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "id": 10,
+      "title": "PipelineRun & TaskRun Counts",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Successful PipelineRuns per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 11,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Succeeded",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Failed PipelineRuns per version per day. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "id": 12,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_PipelineRuns_count_failed'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Failed",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Successful TaskRuns per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 13,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Succeeded",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Failed TaskRuns per version per day. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 90
+      },
+      "id": 14,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__results_TaskRuns_count_failed'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Failed",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 98
+      },
+      "id": 15,
+      "title": "Chains Controller Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Tekton Chains controller mean CPU per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 99
+      },
+      "id": 16,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonChainsController_cpu_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_tektonChainsController_cpu_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Chains Controller CPU (mean)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Tekton Chains controller mean memory (RSS) per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 107
+      },
+      "id": 17,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonChainsController_memory_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_tektonChainsController_memory_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Chains Controller Memory (mean)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Chains controller mean workqueue depth per version per day. High values indicate a signing bottleneck.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 115
+      },
+      "id": 18,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonChainsControllerWorkqueueDepth_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_tektonChainsControllerWorkqueueDepth_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Chains Controller Workqueue Depth",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Chains controller restarts per version per day. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 123
+      },
+      "id": 19,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonChainsController_restarts_range')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_tektonChainsController_restarts_range'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Chains Controller Restarts",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 131
+      },
+      "id": 20,
+      "title": "Cluster & API Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster CPU usage per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 132
+      },
+      "id": 21,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster CPU",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster RSS memory per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 140
+      },
+      "id": 22,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Memory",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "OpenShift API server mean CPU per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 148
+      },
+      "id": 23,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "OpenShift API server mean memory per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 156
+      },
+      "id": 24,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_apiserver_memory_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 164
+      },
+      "id": 25,
+      "title": "etcd",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd MVCC database total size per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 165
+      },
+      "id": 26,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd DB Size",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd request latency per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 173
+      },
+      "id": 27,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Request Duration",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "etcd Pod restarts per version per day. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 181
+      },
+      "id": 28,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_etcd_restarts_range'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Restarts",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Pending pods in kube-scheduler queue per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 189
+      },
+      "id": 29,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Scheduler Pending Pods",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": [
+    "chains",
+    "version-comparison",
+    "performance"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "grafana-postgresql-datasource",
+          "value": "grafana-postgresql-datasource"
+        },
+        "description": "PostgreSQL datasource for Chains metrics",
+        "label": "Datasource",
+        "name": "datasource",
+        "query": "grafana-postgresql-datasource",
+        "regex": ".*grafana-postgresql-datasource.*",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "Standard",
+          "value": "427"
+        },
+        "description": "Chains deployment variant (each maps to a separate Horreum test ID).",
+        "includeAll": false,
+        "label": "Variant",
+        "multi": false,
+        "name": "variant",
+        "options": [
+          {
+            "selected": true,
+            "text": "Standard",
+            "value": "427"
+          },
+          {
+            "selected": false,
+            "text": "HA",
+            "value": "428"
+          },
+          {
+            "selected": false,
+            "text": "QBT (non-HA)",
+            "value": "429"
+          },
+          {
+            "selected": false,
+            "text": "HA + QBT",
+            "value": "430"
+          }
+        ],
+        "query": "Standard : 427,HA : 428,QBT (non-HA) : 429,HA + QBT : 430",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Select versions to compare. Use All to include every version.",
+        "includeAll": true,
+        "label": "Version",
+        "multi": true,
+        "name": "version",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "500",
+          "value": "500"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Select a single test total to compare versions at.",
+        "includeAll": false,
+        "label": "Test Total",
+        "multi": false,
+        "name": "test_total",
+        "query": "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 418\n    AND (\n      (${variant}::INTEGER = 427\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 428\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 429\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 430\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__parameters_test_total' ORDER BY test_total",
+        "refresh": 2,
+        "sort": 3,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-14d",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Chains Version Comparison (v2)",
+  "uid": "Chains_Version_Comparison_v2"
+}

--- a/config/grafonnet-workdir/generated/pipelines-comparison-dashboard.json
+++ b/config/grafonnet-workdir/generated/pipelines-comparison-dashboard.json
@@ -1,7 +1,7 @@
 {
-  "description": "Side-by-side comparison of OpenShift Pipelines performance metrics across different released versions. Select two versions to compare.",
+  "description": "Side-by-side comparison of two versions for the same variant. Select a variant, pick two versions, and see their metrics mirrored left/right. Includes historical data from legacy test 391.",
   "editable": true,
-  "graphTooltip": 1,
+  "graphTooltip": 2,
   "panels": [
     {
       "gridPos": {
@@ -19,18 +19,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of PipelineRuns that completed successfully, averaged per day per concurrency level.",
+      "description": "Average PipelineRun wall-clock duration. Rising trend indicates a regression.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "short"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -40,15 +42,26 @@
         "y": 1
       },
       "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ ' || concurrency AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration @ c' || concurrency AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Succeeded - v${version1}",
+      "title": "PipelineRun Duration (avg) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -56,18 +69,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of PipelineRuns that completed successfully, averaged per day per concurrency level.",
+      "description": "Average PipelineRun wall-clock duration. Rising trend indicates a regression.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "short"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -77,15 +92,26 @@
         "y": 1
       },
       "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ ' || concurrency AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration @ c' || concurrency AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Succeeded - v${version2}",
+      "title": "PipelineRun Duration (avg) — ${version2}",
       "type": "timeseries"
     },
     {
@@ -93,18 +119,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of PipelineRuns that failed, averaged per day per concurrency level. A value of 0 means all runs succeeded.",
+      "description": "Successful PipelineRun phase breakdown:\n- **pending**: scheduling wait\n- **running**: execution time",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "short"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -114,15 +142,26 @@
         "y": 9
       },
       "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ ' || concurrency AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_PipelineRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_Success_pending_avg'\n    AND label_values ? '__results_PipelineRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ c' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ c' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PipelineRun Failed - v${version1}",
+      "title": "PipelineRun Phases (pending / running) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -130,13 +169,115 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of PipelineRuns that failed, averaged per day per concurrency level. A value of 0 means all runs succeeded.",
+      "description": "Successful PipelineRun phase breakdown:\n- **pending**: scheduling wait\n- **running**: execution time",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_PipelineRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_Success_pending_avg'\n    AND label_values ? '__results_PipelineRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ c' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ c' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Phases (pending / running) — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total successful PipelineRuns per day per concurrency level.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ c' || concurrency AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Succeeded — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total successful PipelineRuns per day per concurrency level.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -148,92 +289,29 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 9
-      },
-      "id": 5,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ ' || concurrency AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "PipelineRun Failed - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Average wall-clock duration of all PipelineRuns (creationTimestamp to completionTime), per day per concurrency level.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 17
-      },
-      "id": 6,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration @ ' || concurrency AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "PR Mean Duration - v${version1}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Average wall-clock duration of all PipelineRuns (creationTimestamp to completionTime), per day per concurrency level.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
         "y": 17
       },
       "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration @ ' || concurrency AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ c' || concurrency AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "PR Mean Duration - v${version2}",
+      "title": "PipelineRun Succeeded — ${version2}",
       "type": "timeseries"
     },
     {
@@ -241,18 +319,21 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Breakdown of successful PipelineRun duration into two phases:\n- **pending**: time from creation to start (waiting for scheduling)\n- **running**: time from start to completion (actual execution)\n\nHigh pending time indicates scheduling pressure; high running time indicates slow task execution.",
+      "description": "Failed PipelineRuns. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "s"
+          "unit": "short"
         }
       },
       "gridPos": {
@@ -262,15 +343,26 @@
         "y": 25
       },
       "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_PipelineRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_Success_pending_avg'\n    AND label_values ? '__results_PipelineRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ ' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ ' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ c' || concurrency AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Succeeded PR Metrics (pending / running) - v${version1}",
+      "title": "PipelineRun Failed — ${version1}",
       "type": "timeseries"
     },
     {
@@ -278,18 +370,21 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Breakdown of successful PipelineRun duration into two phases:\n- **pending**: time from creation to start (waiting for scheduling)\n- **running**: time from start to completion (actual execution)\n\nHigh pending time indicates scheduling pressure; high running time indicates slow task execution.",
+      "description": "Failed PipelineRuns. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "s"
+          "unit": "short"
         }
       },
       "gridPos": {
@@ -299,15 +394,26 @@
         "y": 25
       },
       "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_PipelineRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_PipelineRuns_Success_pending_avg'\n    AND label_values ? '__results_PipelineRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ ' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ ' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ c' || concurrency AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Succeeded PR Metrics (pending / running) - v${version2}",
+      "title": "PipelineRun Failed — ${version2}",
       "type": "timeseries"
     },
     {
@@ -326,18 +432,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of TaskRuns that completed successfully, averaged per day per concurrency level. Each PipelineRun creates multiple TaskRuns.",
+      "description": "Average successful TaskRun duration.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "short"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -347,15 +455,26 @@
         "y": 34
       },
       "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ ' || concurrency AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_duration_avg')::DOUBLE PRECISION) AS tr_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_duration @ c' || concurrency AS metric,\n  tr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Succeeded - v${version1}",
+      "title": "TaskRun Duration (avg) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -363,18 +482,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of TaskRuns that completed successfully, averaged per day per concurrency level. Each PipelineRun creates multiple TaskRuns.",
+      "description": "Average successful TaskRun duration.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "short"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -384,15 +505,26 @@
         "y": 34
       },
       "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ ' || concurrency AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_duration_avg')::DOUBLE PRECISION) AS tr_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_duration @ c' || concurrency AS metric,\n  tr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Succeeded - v${version2}",
+      "title": "TaskRun Duration (avg) — ${version2}",
       "type": "timeseries"
     },
     {
@@ -400,18 +532,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of TaskRuns that failed, averaged per day per concurrency level.",
+      "description": "Successful TaskRun phase breakdown:\n- **pending**: Pod scheduling wait\n- **running**: container execution time",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "short"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -421,15 +555,26 @@
         "y": 42
       },
       "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ ' || concurrency AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_TaskRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_Success_pending_avg'\n    AND label_values ? '__results_TaskRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ c' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ c' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun Failed - v${version1}",
+      "title": "TaskRun Phases (pending / running) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -437,13 +582,115 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of TaskRuns that failed, averaged per day per concurrency level.",
+      "description": "Successful TaskRun phase breakdown:\n- **pending**: Pod scheduling wait\n- **running**: container execution time",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_TaskRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_Success_pending_avg'\n    AND label_values ? '__results_TaskRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ c' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ c' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Phases (pending / running) — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total successful TaskRuns per day per concurrency level.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ c' || concurrency AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Succeeded — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total successful TaskRuns per day per concurrency level.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -455,92 +702,29 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
-      },
-      "id": 14,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ ' || concurrency AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "TaskRun Failed - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Average wall-clock duration of successful TaskRuns (creationTimestamp to completionTime), per day per concurrency level.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 50
-      },
-      "id": 15,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_duration_avg')::DOUBLE PRECISION) AS tr_duration\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_duration @ ' || concurrency AS metric,\n  tr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "TR Mean Success Duration - v${version1}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Average wall-clock duration of successful TaskRuns (creationTimestamp to completionTime), per day per concurrency level.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
         "y": 50
       },
       "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_duration_avg')::DOUBLE PRECISION) AS tr_duration\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_duration @ ' || concurrency AS metric,\n  tr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ c' || concurrency AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TR Mean Success Duration - v${version2}",
+      "title": "TaskRun Succeeded — ${version2}",
       "type": "timeseries"
     },
     {
@@ -548,18 +732,21 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Breakdown of successful TaskRun duration into two phases:\n- **pending**: time from creation to start (waiting for Pod scheduling)\n- **running**: time from start to completion (actual container execution)\n\nHigh pending time indicates Pod scheduling delays or resource pressure.",
+      "description": "Failed TaskRuns. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "s"
+          "unit": "short"
         }
       },
       "gridPos": {
@@ -569,15 +756,26 @@
         "y": 58
       },
       "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_TaskRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_Success_pending_avg'\n    AND label_values ? '__results_TaskRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ ' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ ' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ c' || concurrency AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Succeeded TR Metrics (pending / running) - v${version1}",
+      "title": "TaskRun Failed — ${version1}",
       "type": "timeseries"
     },
     {
@@ -585,18 +783,21 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Breakdown of successful TaskRun duration into two phases:\n- **pending**: time from creation to start (waiting for Pod scheduling)\n- **running**: time from start to completion (actual container execution)\n\nHigh pending time indicates Pod scheduling delays or resource pressure.",
+      "description": "Failed TaskRuns. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "s"
+          "unit": "short"
         }
       },
       "gridPos": {
@@ -606,15 +807,26 @@
         "y": 58
       },
       "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_TaskRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRuns_Success_pending_avg'\n    AND label_values ? '__results_TaskRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ ' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ ' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ c' || concurrency AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Succeeded TR Metrics (pending / running) - v${version2}",
+      "title": "TaskRun Failed — ${version2}",
       "type": "timeseries"
     },
     {
@@ -625,7 +837,7 @@
         "y": 66
       },
       "id": 19,
-      "title": "Controller Metrics",
+      "title": "Controller Health",
       "type": "row"
     },
     {
@@ -633,13 +845,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean time between TaskRun creation and its corresponding Pod creation. Measures how long the Tekton controller takes to reconcile a TaskRun and create the Pod. High values indicate controller backlog.",
+      "description": "Mean time from TaskRun creation to Pod creation. High values indicate controller backlog.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -654,15 +868,26 @@
         "y": 67
       },
       "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRunsToPods_creationTimestampDiff_mean')::DOUBLE PRECISION) AS pod_creation_lag\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRunsToPods_creationTimestampDiff_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pod_creation_lag @ ' || concurrency AS metric,\n  pod_creation_lag AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRunsToPods_creationTimestampDiff_mean')::DOUBLE PRECISION) AS pod_creation_lag\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRunsToPods_creationTimestampDiff_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pod_creation_lag @ c' || concurrency AS metric,\n  pod_creation_lag AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun to Pod Creation Duration - v${version1}",
+      "title": "TaskRun → Pod Creation Lag — ${version1}",
       "type": "timeseries"
     },
     {
@@ -670,13 +895,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean time between TaskRun creation and its corresponding Pod creation. Measures how long the Tekton controller takes to reconcile a TaskRun and create the Pod. High values indicate controller backlog.",
+      "description": "Mean time from TaskRun creation to Pod creation. High values indicate controller backlog.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -691,15 +918,26 @@
         "y": 67
       },
       "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRunsToPods_creationTimestampDiff_mean')::DOUBLE PRECISION) AS pod_creation_lag\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__results_TaskRunsToPods_creationTimestampDiff_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pod_creation_lag @ ' || concurrency AS metric,\n  pod_creation_lag AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRunsToPods_creationTimestampDiff_mean')::DOUBLE PRECISION) AS pod_creation_lag\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRunsToPods_creationTimestampDiff_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pod_creation_lag @ c' || concurrency AS metric,\n  pod_creation_lag AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun to Pod Creation Duration - v${version2}",
+      "title": "TaskRun → Pod Creation Lag — ${version2}",
       "type": "timeseries"
     },
     {
@@ -707,13 +945,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean CPU usage of Tekton Pipelines components during the test run, in CPU cores (e.g. 0.06 = 60 millicores).\n- **controller_cpu**: main reconciliation controller\n- **webhook_cpu**: admission webhook\n- **proxy_webhook_cpu**: operator proxy webhook",
+      "description": "Controller work queue depth. High = bottleneck.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -728,15 +968,26 @@
         "y": 75
       },
       "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_cpu_mean')::DOUBLE PRECISION) AS controller_cpu,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_cpu_mean')::DOUBLE PRECISION) AS proxy_webhook_cpu,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_cpu_mean')::DOUBLE PRECISION) AS webhook_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonPipelinesController_cpu_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_cpu_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_cpu @ ' || concurrency AS metric,\n  controller_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook_cpu @ ' || concurrency AS metric,\n  proxy_webhook_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_cpu @ ' || concurrency AS metric,\n  webhook_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS workqueue_depth\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'workqueue_depth @ c' || concurrency AS metric,\n  workqueue_depth AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Controllers CPU Usage (Mean) - v${version1}",
+      "title": "Controller Workqueue Depth — ${version1}",
       "type": "timeseries"
     },
     {
@@ -744,13 +995,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean CPU usage of Tekton Pipelines components during the test run, in CPU cores (e.g. 0.06 = 60 millicores).\n- **controller_cpu**: main reconciliation controller\n- **webhook_cpu**: admission webhook\n- **proxy_webhook_cpu**: operator proxy webhook",
+      "description": "Controller work queue depth. High = bottleneck.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -765,15 +1018,26 @@
         "y": 75
       },
       "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_cpu_mean')::DOUBLE PRECISION) AS controller_cpu,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_cpu_mean')::DOUBLE PRECISION) AS proxy_webhook_cpu,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_cpu_mean')::DOUBLE PRECISION) AS webhook_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonPipelinesController_cpu_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_cpu_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_cpu @ ' || concurrency AS metric,\n  controller_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook_cpu @ ' || concurrency AS metric,\n  proxy_webhook_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_cpu @ ' || concurrency AS metric,\n  webhook_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS workqueue_depth\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'workqueue_depth @ c' || concurrency AS metric,\n  workqueue_depth AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Controllers CPU Usage (Mean) - v${version2}",
+      "title": "Controller Workqueue Depth — ${version2}",
       "type": "timeseries"
     },
     {
@@ -781,18 +1045,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean memory (RSS) usage of Tekton Pipelines components during the test run.\n- **controller_mem**: main reconciliation controller\n- **webhook_mem**: admission webhook\n- **proxy_webhook_mem**: operator proxy webhook",
+      "description": "Controller → API server HTTP latency.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "bytes"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -802,15 +1068,26 @@
         "y": 83
       },
       "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_memory_mean')::DOUBLE PRECISION) AS controller_mem,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_memory_mean')::DOUBLE PRECISION) AS proxy_webhook_mem,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_memory_mean')::DOUBLE PRECISION) AS webhook_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonPipelinesController_memory_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_memory_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_mem @ ' || concurrency AS metric,\n  controller_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook_mem @ ' || concurrency AS metric,\n  proxy_webhook_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_mem @ ' || concurrency AS metric,\n  webhook_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesControllerClientLatencyAverage_mean')::DOUBLE PRECISION) AS client_latency\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonPipelinesControllerClientLatencyAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'client_latency @ c' || concurrency AS metric,\n  client_latency AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Controllers Memory Usage (Mean) - v${version1}",
+      "title": "Controller Client Latency — ${version1}",
       "type": "timeseries"
     },
     {
@@ -818,18 +1095,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean memory (RSS) usage of Tekton Pipelines components during the test run.\n- **controller_mem**: main reconciliation controller\n- **webhook_mem**: admission webhook\n- **proxy_webhook_mem**: operator proxy webhook",
+      "description": "Controller → API server HTTP latency.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "bytes"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -839,174 +1118,37 @@
         "y": 83
       },
       "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_memory_mean')::DOUBLE PRECISION) AS controller_mem,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_memory_mean')::DOUBLE PRECISION) AS proxy_webhook_mem,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_memory_mean')::DOUBLE PRECISION) AS webhook_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonPipelinesController_memory_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_memory_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_mem @ ' || concurrency AS metric,\n  controller_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook_mem @ ' || concurrency AS metric,\n  proxy_webhook_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_mem @ ' || concurrency AS metric,\n  webhook_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesControllerClientLatencyAverage_mean')::DOUBLE PRECISION) AS client_latency\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonPipelinesControllerClientLatencyAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'client_latency @ c' || concurrency AS metric,\n  client_latency AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Controllers Memory Usage (Mean) - v${version2}",
+      "title": "Controller Client Latency — ${version2}",
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean depth of the Tekton Pipelines controller workqueue during the test. A growing workqueue indicates the controller cannot reconcile objects fast enough. Consistently high values suggest the controller is a bottleneck.\n\nNote: Nightly builds using Tekton >= v1.10 report this as kn_workqueue_depth (OpenTelemetry).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "short"
-        }
-      },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 1,
+        "w": 24,
         "x": 0,
         "y": 91
       },
       "id": 26,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS workqueue_depth\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'workqueue_depth @ ' || concurrency AS metric,\n  workqueue_depth AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Pipelines Controller Workqueue Depth - v${version1}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean depth of the Tekton Pipelines controller workqueue during the test. A growing workqueue indicates the controller cannot reconcile objects fast enough. Consistently high values suggest the controller is a bottleneck.\n\nNote: Nightly builds using Tekton >= v1.10 report this as kn_workqueue_depth (OpenTelemetry).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 91
-      },
-      "id": 27,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS workqueue_depth\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'workqueue_depth @ ' || concurrency AS metric,\n  workqueue_depth AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Pipelines Controller Workqueue Depth - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean HTTP client latency (p50) of the Tekton Pipelines controller when communicating with the Kubernetes API server. High latency indicates API server pressure or network issues.\n\nNote: Nightly builds using Tekton >= v1.10 report this as http_client_request_duration_seconds (OpenTelemetry).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 99
-      },
-      "id": 28,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesControllerClientLatencyAverage_mean')::DOUBLE PRECISION) AS client_latency\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonPipelinesControllerClientLatencyAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'client_latency @ ' || concurrency AS metric,\n  client_latency AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Pipelines Controller Client Latency - v${version1}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean HTTP client latency (p50) of the Tekton Pipelines controller when communicating with the Kubernetes API server. High latency indicates API server pressure or network issues.\n\nNote: Nightly builds using Tekton >= v1.10 report this as http_client_request_duration_seconds (OpenTelemetry).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 99
-      },
-      "id": 29,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesControllerClientLatencyAverage_mean')::DOUBLE PRECISION) AS client_latency\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_tektonPipelinesControllerClientLatencyAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'client_latency @ ' || concurrency AS metric,\n  client_latency AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Pipelines Controller Client Latency - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 107
-      },
-      "id": 30,
-      "title": "Cluster & API Server Metrics",
+      "title": "Component Resources",
       "type": "row"
     },
     {
@@ -1014,13 +1156,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean total CPU usage rate across all cluster nodes during the test run, in CPU cores.",
+      "description": "Mean CPU of Tekton Pipelines components (cores).\n- **controller_cpu**: reconciliation loop\n- **webhook_cpu**: admission webhook\n- **proxy_cpu**: operator proxy webhook",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1031,289 +1175,191 @@
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 0,
+        "y": 92
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_cpu_mean')::DOUBLE PRECISION) AS controller_cpu,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_cpu_mean')::DOUBLE PRECISION) AS proxy_cpu,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_cpu_mean')::DOUBLE PRECISION) AS webhook_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_cpu_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_cpu_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_cpu @ c' || concurrency AS metric,\n  controller_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_cpu @ c' || concurrency AS metric,\n  proxy_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_cpu @ c' || concurrency AS metric,\n  webhook_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Tekton CPU (controller / webhook / proxy) — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean CPU of Tekton Pipelines components (cores).\n- **controller_cpu**: reconciliation loop\n- **webhook_cpu**: admission webhook\n- **proxy_cpu**: operator proxy webhook",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 92
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_cpu_mean')::DOUBLE PRECISION) AS controller_cpu,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_cpu_mean')::DOUBLE PRECISION) AS proxy_cpu,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_cpu_mean')::DOUBLE PRECISION) AS webhook_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_cpu_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_cpu_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_cpu @ c' || concurrency AS metric,\n  controller_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_cpu @ c' || concurrency AS metric,\n  proxy_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_cpu @ c' || concurrency AS metric,\n  webhook_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Tekton CPU (controller / webhook / proxy) — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean memory (RSS) of Tekton Pipelines components.\n- **controller_mem**: reconciliation loop\n- **webhook_mem**: admission webhook\n- **proxy_mem**: operator proxy webhook",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 100
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_memory_mean')::DOUBLE PRECISION) AS controller_mem,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_memory_mean')::DOUBLE PRECISION) AS proxy_mem,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_memory_mean')::DOUBLE PRECISION) AS webhook_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_memory_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_memory_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_mem @ c' || concurrency AS metric,\n  controller_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_mem @ c' || concurrency AS metric,\n  proxy_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_mem @ c' || concurrency AS metric,\n  webhook_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Tekton Memory (controller / webhook / proxy) — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean memory (RSS) of Tekton Pipelines components.\n- **controller_mem**: reconciliation loop\n- **webhook_mem**: admission webhook\n- **proxy_mem**: operator proxy webhook",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 100
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_memory_mean')::DOUBLE PRECISION) AS controller_mem,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_memory_mean')::DOUBLE PRECISION) AS proxy_mem,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_memory_mean')::DOUBLE PRECISION) AS webhook_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_memory_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_memory_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_mem @ c' || concurrency AS metric,\n  controller_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_mem @ c' || concurrency AS metric,\n  proxy_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_mem @ c' || concurrency AS metric,\n  webhook_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Tekton Memory (controller / webhook / proxy) — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
         "x": 0,
         "y": 108
       },
       "id": 31,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ ' || concurrency AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Cluster CPU Usage - v${version1}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean total CPU usage rate across all cluster nodes during the test run, in CPU cores.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 108
-      },
-      "id": 32,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ ' || concurrency AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Cluster CPU Usage - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean total RSS memory usage across all cluster nodes during the test run.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 116
-      },
-      "id": 33,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ ' || concurrency AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Cluster Memory Usage - v${version1}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean total RSS memory usage across all cluster nodes during the test run.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 116
-      },
-      "id": 34,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ ' || concurrency AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Cluster Memory Usage - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean CPU usage of the OpenShift API server and Kubernetes API server during the test run.\n- **apiserver_cpu**: openshift-apiserver\n- **kube_apiserver_cpu**: kube-apiserver",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 124
-      },
-      "id": 35,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS apiserver_cpu,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_cpu @ ' || concurrency AS metric,\n  apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ ' || concurrency AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "OpenShift and Kube API Server CPU Usage (Mean) - v${version1}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean CPU usage of the OpenShift API server and Kubernetes API server during the test run.\n- **apiserver_cpu**: openshift-apiserver\n- **kube_apiserver_cpu**: kube-apiserver",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 124
-      },
-      "id": 36,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS apiserver_cpu,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_cpu @ ' || concurrency AS metric,\n  apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ ' || concurrency AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "OpenShift and Kube API Server CPU Usage (Mean) - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean memory (RSS) usage of the OpenShift API server and Kubernetes API server during the test run.\n- **apiserver_mem**: openshift-apiserver\n- **kube_apiserver_mem**: kube-apiserver",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 132
-      },
-      "id": 37,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS apiserver_mem,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_memory_mean'\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_mem @ ' || concurrency AS metric,\n  apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ ' || concurrency AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "OpenShift and Kube API Server Memory Usage (Mean) - v${version1}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean memory (RSS) usage of the OpenShift API server and Kubernetes API server during the test run.\n- **apiserver_mem**: openshift-apiserver\n- **kube_apiserver_mem**: kube-apiserver",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 132
-      },
-      "id": 38,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS apiserver_mem,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_apiserver_memory_mean'\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_mem @ ' || concurrency AS metric,\n  apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ ' || concurrency AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "OpenShift and Kube API Server Memory Usage (Mean) - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 140
-      },
-      "id": 39,
-      "title": "etcd Metrics",
+      "title": "Cluster & API Server",
       "type": "row"
     },
     {
@@ -1321,13 +1367,115 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean etcd MVCC database size during the test run.\n- **db_total**: total allocated size on disk\n- **db_in_use**: logical size of live data\n\nA large gap between total and in-use indicates fragmentation; an etcd defrag may be needed.",
+      "description": "Mean total cluster CPU usage rate (cores).",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 109
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ c' || concurrency AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster CPU — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster CPU usage rate (cores).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 109
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ c' || concurrency AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster CPU — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster RSS memory.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1338,19 +1486,341 @@
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 0,
+        "y": 117
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ c' || concurrency AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Memory — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster RSS memory.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 117
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ c' || concurrency AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Memory — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean API server CPU (cores).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 125
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS ocp_apiserver_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ c' || concurrency AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_cpu @ c' || concurrency AS metric,\n  ocp_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU (OpenShift / Kube) — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean API server CPU (cores).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 125
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS ocp_apiserver_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ c' || concurrency AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_cpu @ c' || concurrency AS metric,\n  ocp_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU (OpenShift / Kube) — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean API server memory.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 133
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS ocp_apiserver_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n    AND label_values ? '__measurements_apiserver_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ c' || concurrency AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_mem @ c' || concurrency AS metric,\n  ocp_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory (OpenShift / Kube) — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean API server memory.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 133
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS ocp_apiserver_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n    AND label_values ? '__measurements_apiserver_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ c' || concurrency AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_mem @ c' || concurrency AS metric,\n  ocp_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory (OpenShift / Kube) — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
         "x": 0,
         "y": 141
       },
       "id": 40,
+      "title": "etcd",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "etcd MVCC DB size.\n- **db_total**: allocated on disk\n- **db_in_use**: live data",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 142
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ ' || concurrency AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ ' || concurrency AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ c' || concurrency AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ c' || concurrency AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd MVCC DB Size (Mean) - v${version1}",
+      "title": "etcd DB Size (total / in-use) — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1358,13 +1828,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean etcd MVCC database size during the test run.\n- **db_total**: total allocated size on disk\n- **db_in_use**: logical size of live data\n\nA large gap between total and in-use indicates fragmentation; an etcd defrag may be needed.",
+      "description": "etcd MVCC DB size.\n- **db_total**: allocated on disk\n- **db_in_use**: live data",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1376,55 +1848,29 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 141
-      },
-      "id": 41,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ ' || concurrency AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ ' || concurrency AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "etcd MVCC DB Size (Mean) - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean and peak etcd request durations during the test run.\n- **req_duration_mean**: average latency per request\n- **req_duration_max**: worst-case latency observed\n\nHigh values indicate etcd pressure, disk I/O issues, or large key-value operations.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 149
+        "y": 142
       },
       "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ ' || concurrency AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ ' || concurrency AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ c' || concurrency AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ c' || concurrency AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd Request Duration (Mean) - v${version1}",
+      "title": "etcd DB Size (total / in-use) — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1432,13 +1878,65 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean and peak etcd request durations during the test run.\n- **req_duration_mean**: average latency per request\n- **req_duration_max**: worst-case latency observed\n\nHigh values indicate etcd pressure, disk I/O issues, or large key-value operations.",
+      "description": "etcd request latency.\n- **mean**: average\n- **max**: worst-case peak",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 150
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'max @ c' || concurrency AS metric,\n  max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mean @ c' || concurrency AS metric,\n  mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Request Duration (mean / max) — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "etcd request latency.\n- **mean**: average\n- **max**: worst-case peak",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1450,55 +1948,29 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 149
-      },
-      "id": 43,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ ' || concurrency AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ ' || concurrency AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "etcd Request Duration (Mean) - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Number of etcd Pod restarts during the test run. Should be 0 under normal conditions. Restarts indicate OOM kills, liveness probe failures, or cluster instability.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 157
+        "y": 150
       },
       "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd_restarts\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcd_restarts_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd_restarts @ ' || concurrency AS metric,\n  etcd_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'max @ c' || concurrency AS metric,\n  max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mean @ c' || concurrency AS metric,\n  mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd Restarts - v${version1}",
+      "title": "etcd Request Duration (mean / max) — ${version2}",
       "type": "timeseries"
     },
     {
@@ -1506,50 +1978,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Number of etcd Pod restarts during the test run. Should be 0 under normal conditions. Restarts indicate OOM kills, liveness probe failures, or cluster instability.",
+      "description": "etcd Pod restarts. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 157
-      },
-      "id": 45,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd_restarts\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_etcd_restarts_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd_restarts @ ' || concurrency AS metric,\n  etcd_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "etcd Restarts - v${version2}",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Range of pending pods in the kube-scheduler queue during the test run. High values indicate scheduling pressure caused by insufficient node resources or excessive Pod creation rate.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1561,18 +1999,29 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 165
+        "y": 158
       },
-      "id": 46,
+      "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version1}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ ' || concurrency AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd_restarts\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_etcd_restarts_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd_restarts @ c' || concurrency AS metric,\n  etcd_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Scheduler Pending Pods - v${version1}",
+      "title": "etcd Restarts — ${version1}",
       "type": "timeseries"
     },
     {
@@ -1580,13 +2029,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Range of pending pods in the kube-scheduler queue during the test run. High values indicate scheduling pressure caused by insufficient node resources or excessive Pod creation rate.",
+      "description": "etcd Pod restarts. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -1598,23 +2050,141 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 165
+        "y": 158
       },
-      "id": 47,
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND label_values ? '__deployment_version'\nAND (label_values->>'__deployment_version') = '${version2}'\nAND label_values ? '__deployment_nightly'\nAND (label_values->>'__deployment_nightly')::BOOLEAN = false\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ ' || concurrency AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd_restarts\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_etcd_restarts_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd_restarts @ c' || concurrency AS metric,\n  etcd_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Scheduler Pending Pods - v${version2}",
+      "title": "etcd Restarts — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Pending pods in kube-scheduler queue.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 166
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ c' || concurrency AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Scheduler Pending Pods — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Pending pods in kube-scheduler queue.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5,
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 166
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ c' || concurrency AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Scheduler Pending Pods — ${version2}",
       "type": "timeseries"
     }
   ],
   "refresh": "5m",
   "schemaVersion": 39,
+  "tags": [
+    "pipelines",
+    "comparison",
+    "performance"
+  ],
   "templating": {
     "list": [
       {
@@ -1633,79 +2203,79 @@
       {
         "current": {
           "text": "Standard",
-          "value": "standard"
+          "value": "423"
         },
-        "description": "Filter by deployment configuration: Standard, HA, QBT, or HA+QBT.",
+        "description": "Pipeline deployment variant (each maps to a separate Horreum test ID).",
         "includeAll": false,
-        "label": "Deployment Configuration",
+        "label": "Variant",
         "multi": false,
-        "name": "deploy_config",
+        "name": "variant",
         "options": [
           {
             "selected": true,
             "text": "Standard",
-            "value": "standard"
+            "value": "423"
           },
           {
             "selected": false,
             "text": "HA - Deployments",
-            "value": "ha-deployments"
+            "value": "419"
           },
           {
             "selected": false,
             "text": "HA - StatefulSets",
-            "value": "ha-statefulsets"
+            "value": "421"
           },
           {
             "selected": false,
             "text": "QBT (non-HA)",
-            "value": "qbt"
+            "value": "422"
           },
           {
             "selected": false,
-            "text": "HA + QBT - Deployments",
-            "value": "ha-qbt-deployments"
+            "text": "HA + QBT",
+            "value": "420"
           }
         ],
-        "query": "Standard : standard,HA - Deployments : ha-deployments,HA - StatefulSets : ha-statefulsets,QBT (non-HA) : qbt,HA + QBT - Deployments : ha-qbt-deployments",
+        "query": "Standard : 423,HA - Deployments : 419,HA - StatefulSets : 421,QBT (non-HA) : 422,HA + QBT : 420",
         "type": "custom"
       },
       {
         "current": {
-          "text": "1.19",
-          "value": "1.19"
+          "text": "nightly",
+          "value": "nightly"
         },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "${datasource}"
         },
-        "description": "Version 1 for comparison",
+        "description": "Version 1 for comparison.",
         "includeAll": false,
         "label": "Version 1",
         "multi": false,
         "name": "version1",
-        "query": "SELECT DISTINCT (label_values->>'__deployment_version') AS __text FROM data WHERE horreum_testid = 391 AND label_values ? '__deployment_version' AND (label_values->>'__deployment_version') IS NOT NULL AND (label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = false) ORDER BY __text",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
         "refresh": 2,
-        "sort": 3,
+        "sort": 0,
         "type": "query"
       },
       {
         "current": {
-          "text": "1.20",
-          "value": "1.20"
+          "text": "1.23",
+          "value": "1.23"
         },
         "datasource": {
           "type": "grafana-postgresql-datasource",
           "uid": "${datasource}"
         },
-        "description": "Version 2 for comparison",
+        "description": "Version 2 for comparison.",
         "includeAll": false,
         "label": "Version 2",
         "multi": false,
         "name": "version2",
-        "query": "SELECT DISTINCT (label_values->>'__deployment_version') AS __text FROM data WHERE horreum_testid = 391 AND label_values ? '__deployment_version' AND (label_values->>'__deployment_version') IS NOT NULL AND (label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = false) ORDER BY __text",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
         "refresh": 2,
-        "sort": 3,
+        "sort": 0,
         "type": "query"
       },
       {
@@ -1722,7 +2292,7 @@
         "label": "Concurrency",
         "multi": true,
         "name": "concurrency",
-        "query": "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE horreum_testid = 391 AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency",
+        "query": "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency",
         "refresh": 2,
         "sort": 3,
         "type": "query"
@@ -1734,6 +2304,6 @@
     "to": "now"
   },
   "timezone": "utc",
-  "title": "Pipelines Performance Comparison Dashboard",
+  "title": "Pipelines Performance Comparison",
   "uid": "Pipelines_Performance_Comparison"
 }

--- a/config/grafonnet-workdir/generated/pipelines-dashboard.json
+++ b/config/grafonnet-workdir/generated/pipelines-dashboard.json
@@ -1,7 +1,7 @@
 {
-  "description": "OpenShift Pipelines nightly build performance. Use the Deployment Configuration variable to switch between Standard, HA, QBT, and HA+QBT setups.",
+  "description": "OpenShift Pipelines performance trends per variant and version. Includes historical data from legacy test 391 and new per-variant tests (419-423). Select a variant, version, and concurrency level to track regressions over time.",
   "editable": true,
-  "graphTooltip": 1,
+  "graphTooltip": 2,
   "panels": [
     {
       "gridPos": {
@@ -19,13 +19,115 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
+      "description": "Average wall-clock duration of all PipelineRuns (creationTimestamp → completionTime), per day per concurrency level. Rising trend indicates a regression.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration @ c' || concurrency AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Duration (avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Breakdown of successful PipelineRun duration into two phases:\n- **pending**: time from creation to start (waiting for scheduling)\n- **running**: time from start to completion (actual execution)\n\nHigh pending → scheduling pressure. High running → slow task execution.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_PipelineRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_Success_pending_avg'\n    AND label_values ? '__results_PipelineRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ c' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ c' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Phases (pending / running)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
       "description": "Total number of PipelineRuns that completed successfully, averaged per day per concurrency level.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -37,14 +139,25 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 1
+        "y": 9
       },
-      "id": 2,
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ ' || concurrency AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ c' || concurrency AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -56,13 +169,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of PipelineRuns that failed, averaged per day per concurrency level. A value of 0 means all runs succeeded.",
+      "description": "PipelineRuns that failed. Should be 0. Any non-zero value indicates test failures worth investigating.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -74,92 +190,29 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 1
+        "y": 9
       },
-      "id": 3,
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ ' || concurrency AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION) AS pr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_PipelineRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_failed @ c' || concurrency AS metric,\n  pr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
       "title": "PipelineRun Failed",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Average wall-clock duration of all PipelineRuns (creationTimestamp to completionTime), per day per concurrency level.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 9
-      },
-      "id": 4,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration @ ' || concurrency AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "PR Mean Duration",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Breakdown of successful PipelineRun duration into two phases:\n- **pending**: time from creation to start (waiting for scheduling)\n- **running**: time from start to completion (actual execution)\n\nHigh pending time indicates scheduling pressure; high running time indicates slow task execution.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "id": 5,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_PipelineRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_PipelineRuns_Success_pending_avg'\n    AND label_values ? '__results_PipelineRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ ' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ ' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Succeeded PR Metrics (pending / running)",
       "type": "timeseries"
     },
     {
@@ -178,13 +231,115 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
+      "description": "Average wall-clock duration of successful TaskRuns (creationTimestamp → completionTime), per day per concurrency level.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_duration_avg')::DOUBLE PRECISION) AS tr_duration\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_duration @ c' || concurrency AS metric,\n  tr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Duration (avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Breakdown of successful TaskRun duration into two phases:\n- **pending**: time from creation to start (waiting for Pod scheduling)\n- **running**: time from start to completion (actual container execution)\n\nHigh pending → Pod scheduling delays or resource pressure.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_TaskRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_Success_pending_avg'\n    AND label_values ? '__results_TaskRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ c' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ c' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Phases (pending / running)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
       "description": "Total number of TaskRuns that completed successfully, averaged per day per concurrency level. Each PipelineRun creates multiple TaskRuns.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -196,14 +351,25 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 26
       },
-      "id": 7,
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ ' || concurrency AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION) AS tr_succeeded\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_succeeded @ c' || concurrency AS metric,\n  tr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -215,13 +381,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Total number of TaskRuns that failed, averaged per day per concurrency level.",
+      "description": "TaskRuns that failed. Should be 0.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -233,92 +402,29 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 26
       },
-      "id": 8,
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ ' || concurrency AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION) AS tr_failed\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRuns_count_failed'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_failed @ c' || concurrency AS metric,\n  tr_failed AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
       "title": "TaskRun Failed",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Average wall-clock duration of successful TaskRuns (creationTimestamp to completionTime), per day per concurrency level.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 26
-      },
-      "id": 9,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_duration_avg')::DOUBLE PRECISION) AS tr_duration\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_TaskRuns_duration_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'tr_duration @ ' || concurrency AS metric,\n  tr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "TR Mean Success Duration",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Breakdown of successful TaskRun duration into two phases:\n- **pending**: time from creation to start (waiting for Pod scheduling)\n- **running**: time from start to completion (actual container execution)\n\nHigh pending time indicates Pod scheduling delays or resource pressure.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 26
-      },
-      "id": 10,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_Success_pending_avg')::DOUBLE PRECISION) AS pending,\n    AVG((label_values->>'__results_TaskRuns_Success_running_avg')::DOUBLE PRECISION) AS running\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_TaskRuns_Success_pending_avg'\n    AND label_values ? '__results_TaskRuns_Success_running_avg'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending @ ' || concurrency AS metric,\n  pending AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'running @ ' || concurrency AS metric,\n  running AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Succeeded TR Metrics (pending / running)",
       "type": "timeseries"
     },
     {
@@ -329,7 +435,7 @@
         "y": 34
       },
       "id": 11,
-      "title": "Controller Metrics",
+      "title": "Controller Health",
       "type": "row"
     },
     {
@@ -342,8 +448,10 @@
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -358,15 +466,26 @@
         "y": 35
       },
       "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRunsToPods_creationTimestampDiff_mean')::DOUBLE PRECISION) AS pod_creation_lag\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__results_TaskRunsToPods_creationTimestampDiff_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pod_creation_lag @ ' || concurrency AS metric,\n  pod_creation_lag AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRunsToPods_creationTimestampDiff_mean')::DOUBLE PRECISION) AS pod_creation_lag\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__results_TaskRunsToPods_creationTimestampDiff_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pod_creation_lag @ c' || concurrency AS metric,\n  pod_creation_lag AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "TaskRun to Pod Creation Duration",
+      "title": "TaskRun → Pod Creation Lag",
       "type": "timeseries"
     },
     {
@@ -374,13 +493,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean CPU usage of Tekton Pipelines components during the test run, in CPU cores (e.g. 0.06 = 60 millicores).\n- **controller_cpu**: main reconciliation controller\n- **webhook_cpu**: admission webhook\n- **proxy_webhook_cpu**: operator proxy webhook",
+      "description": "Mean depth of the Tekton Pipelines controller work queue. A growing queue means the controller cannot reconcile objects fast enough.\n\nNote: Tekton >= v1.10 reports this as kn_workqueue_depth (OpenTelemetry).",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -395,15 +516,26 @@
         "y": 35
       },
       "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_cpu_mean')::DOUBLE PRECISION) AS controller_cpu,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_cpu_mean')::DOUBLE PRECISION) AS proxy_webhook_cpu,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_cpu_mean')::DOUBLE PRECISION) AS webhook_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_tektonPipelinesController_cpu_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_cpu_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_cpu @ ' || concurrency AS metric,\n  controller_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook_cpu @ ' || concurrency AS metric,\n  proxy_webhook_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_cpu @ ' || concurrency AS metric,\n  webhook_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS workqueue_depth\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'workqueue_depth @ c' || concurrency AS metric,\n  workqueue_depth AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Controllers CPU Usage (Mean)",
+      "title": "Controller Workqueue Depth",
       "type": "timeseries"
     },
     {
@@ -411,18 +543,20 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean memory (RSS) usage of Tekton Pipelines components during the test run.\n- **controller_mem**: main reconciliation controller\n- **webhook_mem**: admission webhook\n- **proxy_webhook_mem**: operator proxy webhook",
+      "description": "Mean HTTP client latency of the Tekton Pipelines controller when communicating with the Kubernetes API server. High latency indicates API server pressure or network issues.\n\nNote: Tekton >= v1.10 reports this as http_client_request_duration_seconds (OpenTelemetry).",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
           "min": 0,
-          "unit": "bytes"
+          "unit": "s"
         }
       },
       "gridPos": {
@@ -432,89 +566,26 @@
         "y": 43
       },
       "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_memory_mean')::DOUBLE PRECISION) AS controller_mem,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_memory_mean')::DOUBLE PRECISION) AS proxy_webhook_mem,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_memory_mean')::DOUBLE PRECISION) AS webhook_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_tektonPipelinesController_memory_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_memory_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_mem @ ' || concurrency AS metric,\n  controller_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_webhook_mem @ ' || concurrency AS metric,\n  proxy_webhook_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_mem @ ' || concurrency AS metric,\n  webhook_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesControllerClientLatencyAverage_mean')::DOUBLE PRECISION) AS client_latency\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonPipelinesControllerClientLatencyAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'client_latency @ c' || concurrency AS metric,\n  client_latency AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "Controllers Memory Usage (Mean)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean depth of the Tekton Pipelines controller workqueue during the test. A growing workqueue indicates the controller cannot reconcile objects fast enough. Consistently high values suggest the controller is a bottleneck.\n\nNote: Nightly builds using Tekton >= v1.10 report this as kn_workqueue_depth (OpenTelemetry).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "short"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 43
-      },
-      "id": 15,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean')::DOUBLE PRECISION) AS workqueue_depth\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'workqueue_depth @ ' || concurrency AS metric,\n  workqueue_depth AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Pipelines Controller Workqueue Depth",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean HTTP client latency (p50) of the Tekton Pipelines controller when communicating with the Kubernetes API server. High latency indicates API server pressure or network issues.\n\nNote: Nightly builds using Tekton >= v1.10 report this as http_client_request_duration_seconds (OpenTelemetry).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "s"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 51
-      },
-      "id": 16,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesControllerClientLatencyAverage_mean')::DOUBLE PRECISION) AS client_latency\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_tektonPipelinesControllerClientLatencyAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'client_latency @ ' || concurrency AS metric,\n  client_latency AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Pipelines Controller Client Latency",
+      "title": "Controller Client Latency",
       "type": "timeseries"
     },
     {
@@ -522,10 +593,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 51
       },
-      "id": 17,
-      "title": "Cluster & API Server Metrics",
+      "id": 15,
+      "title": "Component Resources",
       "type": "row"
     },
     {
@@ -533,13 +604,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean total CPU usage rate across all cluster nodes during the test run, in CPU cores (e.g. 6.5 = 6.5 cores used across the cluster).",
+      "description": "Mean CPU usage of Tekton Pipelines components (in CPU cores, e.g. 0.06 = 60 millicores).\n- **controller_cpu**: main reconciliation loop\n- **webhook_cpu**: admission webhook\n- **proxy_cpu**: operator proxy webhook",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -550,70 +623,107 @@
       "gridPos": {
         "h": 8,
         "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_cpu_mean')::DOUBLE PRECISION) AS controller_cpu,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_cpu_mean')::DOUBLE PRECISION) AS proxy_cpu,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_cpu_mean')::DOUBLE PRECISION) AS webhook_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_cpu_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_cpu_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_cpu @ c' || concurrency AS metric,\n  controller_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_cpu @ c' || concurrency AS metric,\n  proxy_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_cpu @ c' || concurrency AS metric,\n  webhook_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Tekton CPU (controller / webhook / proxy)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean memory (RSS) usage of Tekton Pipelines components.\n- **controller_mem**: main reconciliation loop\n- **webhook_mem**: admission webhook\n- **proxy_mem**: operator proxy webhook",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_memory_mean')::DOUBLE PRECISION) AS controller_mem,\n    AVG((label_values->>'__measurements_tektonOperatorProxyWebhook_memory_mean')::DOUBLE PRECISION) AS proxy_mem,\n    AVG((label_values->>'__measurements_tektonPipelinesWebhook_memory_mean')::DOUBLE PRECISION) AS webhook_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_tektonPipelinesController_memory_mean'\n    AND label_values ? '__measurements_tektonOperatorProxyWebhook_memory_mean'\n    AND label_values ? '__measurements_tektonPipelinesWebhook_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'controller_mem @ c' || concurrency AS metric,\n  controller_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'proxy_mem @ c' || concurrency AS metric,\n  proxy_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'webhook_mem @ c' || concurrency AS metric,\n  webhook_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Tekton Memory (controller / webhook / proxy)",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
         "x": 0,
         "y": 60
       },
       "id": 18,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ ' || concurrency AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Cluster CPU Usage",
-      "type": "timeseries"
+      "title": "Cluster & API Server",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean total RSS memory usage across all cluster nodes during the test run.",
+      "description": "Mean total CPU usage rate across all cluster nodes during the test, in CPU cores.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
-            "showPoints": "always",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "bytes"
-        }
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 60
-      },
-      "id": 19,
-      "pluginVersion": "v11.4.0",
-      "targets": [
-        {
-          "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ ' || concurrency AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
-          "refId": "A"
-        }
-      ],
-      "title": "Cluster Memory Usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "grafana-postgresql-datasource",
-        "uid": "${datasource}"
-      },
-      "description": "Mean CPU usage of the OpenShift API server and Kubernetes API server during the test run, in CPU cores. High values may indicate excessive API calls from the Tekton controller or other components.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -625,18 +735,29 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 61
       },
-      "id": 20,
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS apiserver_cpu,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_cpu @ ' || concurrency AS metric,\n  apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ ' || concurrency AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ c' || concurrency AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "OpenShift and Kube API Server CPU Usage (Mean)",
+      "title": "Cluster CPU",
       "type": "timeseries"
     },
     {
@@ -644,13 +765,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean memory usage of the OpenShift API server and Kubernetes API server during the test run.",
+      "description": "Mean total RSS memory usage across all cluster nodes during the test.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -662,18 +785,129 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 61
       },
-      "id": 21,
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS apiserver_mem,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_apiserver_memory_mean'\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'apiserver_mem @ ' || concurrency AS metric,\n  apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ ' || concurrency AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ c' || concurrency AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "OpenShift and Kube API Server Memory Usage (Mean)",
+      "title": "Cluster Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean CPU usage of the OpenShift and Kubernetes API servers (in CPU cores). High values may indicate excessive API calls from Tekton or other components.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION) AS kube_apiserver_cpu,\n    AVG((label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION) AS ocp_apiserver_cpu\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_cpu @ c' || concurrency AS metric,\n  kube_apiserver_cpu AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_cpu @ c' || concurrency AS metric,\n  ocp_apiserver_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU (OpenShift / Kube)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean memory usage of the OpenShift and Kubernetes API servers.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_kubeApiserver_memory_mean')::DOUBLE PRECISION) AS kube_apiserver_mem,\n    AVG((label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION) AS ocp_apiserver_mem\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_kubeApiserver_memory_mean'\n    AND label_values ? '__measurements_apiserver_memory_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'kube_apiserver_mem @ c' || concurrency AS metric,\n  kube_apiserver_mem AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ocp_apiserver_mem @ c' || concurrency AS metric,\n  ocp_apiserver_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory (OpenShift / Kube)",
       "type": "timeseries"
     },
     {
@@ -681,10 +915,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 77
       },
-      "id": 22,
-      "title": "etcd Metrics",
+      "id": 23,
+      "title": "etcd",
       "type": "row"
     },
     {
@@ -692,13 +926,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Mean etcd MVCC database size during the test run.\n- **db_total**: total allocated DB size on disk\n- **db_in_use**: portion of the DB actively in use\n\nA large gap between total and in-use may indicate fragmentation or the need for defragmentation.",
+      "description": "Mean etcd MVCC database size.\n- **db_total**: total allocated DB size on disk\n- **db_in_use**: portion actively in use\n\nA large gap between the two may indicate fragmentation.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -710,18 +946,29 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 77
+        "y": 78
       },
-      "id": 23,
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ ' || concurrency AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ ' || concurrency AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION) AS db_in_use,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_in_use @ c' || concurrency AS metric,\n  db_in_use AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ c' || concurrency AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd MVCC DB Size (Mean)",
+      "title": "etcd DB Size (total / in-use)",
       "type": "timeseries"
     },
     {
@@ -729,13 +976,15 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Average and maximum etcd request duration during the test run.\n- **req_duration_mean**: average latency across all etcd requests\n- **req_duration_max**: worst-case (peak) etcd request latency\n\nHigh values indicate etcd is under pressure, which can cause slow reconciliation and API server latency.",
+      "description": "etcd request latency.\n- **mean**: average across all requests\n- **max**: worst-case peak latency\n\nHigh values indicate etcd pressure, causing slow reconciliation and API latency.",
       "fieldConfig": {
         "defaults": {
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -747,18 +996,29 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 77
+        "y": 78
       },
-      "id": 24,
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS req_duration_max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration_mean\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_max @ ' || concurrency AS metric,\n  req_duration_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration_mean @ ' || concurrency AS metric,\n  req_duration_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_max')::DOUBLE PRECISION) AS max,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS mean\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_max'\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'max @ c' || concurrency AS metric,\n  max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mean @ c' || concurrency AS metric,\n  mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
-      "title": "etcd Request Duration (Mean)",
+      "title": "etcd Request Duration (mean / max)",
       "type": "timeseries"
     },
     {
@@ -766,13 +1026,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Number of etcd Pod restarts during the test run. Should be 0 under normal conditions. Any restarts indicate instability that likely affected test results.",
+      "description": "etcd Pod restarts during the test. Should be 0. Any restarts indicate instability that likely affected results.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -784,14 +1047,25 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 85
+        "y": 86
       },
-      "id": 25,
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd_restarts\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_etcd_restarts_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd_restarts @ ' || concurrency AS metric,\n  etcd_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION) AS etcd_restarts\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_etcd_restarts_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'etcd_restarts @ c' || concurrency AS metric,\n  etcd_restarts AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -803,13 +1077,16 @@
         "type": "grafana-postgresql-datasource",
         "uid": "${datasource}"
       },
-      "description": "Range of pending pods count in the Kubernetes scheduler during the test run. High values indicate scheduling pressure — pods are waiting for resources or node availability.",
+      "description": "Range of pending pods in the kube-scheduler queue. High values indicate scheduling pressure — pods waiting for resources or node availability.",
       "fieldConfig": {
         "defaults": {
           "custom": {
+            "axisSoftMax": 5,
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "pointSize": 7,
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
             "showPoints": "always",
             "spanNulls": false
           },
@@ -821,14 +1098,25 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 85
+        "y": 86
       },
-      "id": 26,
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "pluginVersion": "v11.4.0",
       "targets": [
         {
           "format": "time_series",
-          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE horreum_testid = 391\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND (\n  ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n  OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n  OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n)\n\n    AND (label_values ? '__deployment_nightly')\nAND (label_values->>'__deployment_nightly')::BOOLEAN = true\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ ' || concurrency AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION) AS pending_pods\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n  GROUP BY day, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pending_pods @ c' || concurrency AS metric,\n  pending_pods AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
           "refId": "A"
         }
       ],
@@ -838,6 +1126,11 @@
   ],
   "refresh": "5m",
   "schemaVersion": 39,
+  "tags": [
+    "pipelines",
+    "trend",
+    "performance"
+  ],
   "templating": {
     "list": [
       {
@@ -856,42 +1149,61 @@
       {
         "current": {
           "text": "Standard",
-          "value": "standard"
+          "value": "423"
         },
-        "description": "Standard, HA (no QBT), QBT (non-HA), or HA+QBT (deployments only). Dashboard shows nightly builds only.",
+        "description": "Pipeline deployment variant (each maps to a separate Horreum test ID).",
         "includeAll": false,
-        "label": "Deployment Configuration",
+        "label": "Variant",
         "multi": false,
-        "name": "deploy_config",
+        "name": "variant",
         "options": [
           {
             "selected": true,
             "text": "Standard",
-            "value": "standard"
+            "value": "423"
           },
           {
             "selected": false,
             "text": "HA - Deployments",
-            "value": "ha-deployments"
+            "value": "419"
           },
           {
             "selected": false,
             "text": "HA - StatefulSets",
-            "value": "ha-statefulsets"
+            "value": "421"
           },
           {
             "selected": false,
             "text": "QBT (non-HA)",
-            "value": "qbt"
+            "value": "422"
           },
           {
             "selected": false,
-            "text": "HA + QBT - Deployments",
-            "value": "ha-qbt-deployments"
+            "text": "HA + QBT",
+            "value": "420"
           }
         ],
-        "query": "Standard : standard,HA - Deployments : ha-deployments,HA - StatefulSets : ha-statefulsets,QBT (non-HA) : qbt,HA + QBT - Deployments : ha-qbt-deployments",
+        "query": "Standard : 423,HA - Deployments : 419,HA - StatefulSets : 421,QBT (non-HA) : 422,HA + QBT : 420",
         "type": "custom"
+      },
+      {
+        "current": {
+          "text": "nightly",
+          "value": "nightly"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Filter to a specific version to track its trend over time.",
+        "includeAll": false,
+        "label": "Version",
+        "multi": false,
+        "name": "version",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
+        "type": "query"
       },
       {
         "current": {
@@ -907,7 +1219,7 @@
         "label": "Concurrency",
         "multi": true,
         "name": "concurrency",
-        "query": "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE horreum_testid = 391 AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency",
+        "query": "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency",
         "refresh": 2,
         "sort": 3,
         "type": "query"

--- a/config/grafonnet-workdir/generated/pipelines-version-comparison-v2.json
+++ b/config/grafonnet-workdir/generated/pipelines-version-comparison-v2.json
@@ -1,0 +1,3267 @@
+{
+  "description": "Daily side-by-side version comparison of OpenShift Pipelines performance.",
+  "editable": true,
+  "graphTooltip": 2,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "title": "Pipeline Performance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average PipelineRun wall-clock duration per version per day. Lower is better.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Duration (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total successful PipelineRuns per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Succeeded",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total failed PipelineRuns per version per day. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 4,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_count_failed')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_PipelineRuns_count_failed'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Failed",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average time a successful PipelineRun waited to be scheduled.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 5,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_Success_pending_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_PipelineRuns_Success_pending_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Pending Time (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average time a successful PipelineRun spent executing.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 6,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_Success_running_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_PipelineRuns_Success_running_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Running Time (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 7,
+      "title": "TaskRun Performance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average successful TaskRun duration per version per day. Lower is better.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 8,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_duration_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_TaskRuns_duration_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Duration (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total successful TaskRuns per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 9,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_count_succeeded')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_TaskRuns_count_succeeded'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Succeeded",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total failed TaskRuns per version per day. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 10,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_count_failed')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_TaskRuns_count_failed'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun Failed",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average Pod scheduling wait for successful TaskRuns.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 11,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_Success_pending_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_TaskRuns_Success_pending_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Pending Time (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average container execution time for successful TaskRuns.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "id": 12,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_Success_running_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_TaskRuns_Success_running_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Running Time (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 13,
+      "title": "Controller Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean time from TaskRun creation to Pod creation.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 83
+      },
+      "id": 14,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRunsToPods_creationTimestampDiff_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__results_TaskRunsToPods_creationTimestampDiff_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TaskRun → Pod Creation Lag",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Tekton Pipelines controller mean CPU (cores).",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 91
+      },
+      "id": 15,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonPipelinesController_cpu_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_tektonPipelinesController_cpu_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Controller CPU",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Tekton Pipelines controller mean memory (RSS).",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 99
+      },
+      "id": 16,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonPipelinesController_memory_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_tektonPipelinesController_memory_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Memory",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Controller workqueue depth. High = bottleneck.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 107
+      },
+      "id": 17,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Depth",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Admission webhook CPU.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 115
+      },
+      "id": 18,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonPipelinesWebhook_cpu_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_tektonPipelinesWebhook_cpu_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook CPU",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Admission webhook memory.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 123
+      },
+      "id": 19,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonPipelinesWebhook_memory_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_tektonPipelinesWebhook_memory_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook Memory",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Controller → API server HTTP latency.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 131
+      },
+      "id": 20,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonPipelinesControllerClientLatencyAverage_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_tektonPipelinesControllerClientLatencyAverage_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Client Latency",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 139
+      },
+      "id": 21,
+      "title": "Cluster & Infrastructure",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster CPU usage rate (cores).",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 140
+      },
+      "id": 22,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster CPU",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster RSS memory.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 148
+      },
+      "id": 23,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Memory",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "OpenShift API server mean CPU.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 156
+      },
+      "id": 24,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_apiserver_cpu_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_apiserver_cpu_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Kubernetes API server mean CPU.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 164
+      },
+      "id": 25,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_kubeApiserver_cpu_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_kubeApiserver_cpu_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Kube API Server CPU",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "OpenShift API server mean memory.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 172
+      },
+      "id": 26,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_apiserver_memory_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_apiserver_memory_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 180
+      },
+      "id": 27,
+      "title": "etcd",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd MVCC database total size.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 181
+      },
+      "id": 28,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd DB Size",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd live data size.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 189
+      },
+      "id": 29,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd DB In Use",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd request latency.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 197
+      },
+      "id": 30,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Request Duration",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "etcd Pod restarts. Should be 0.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 205
+      },
+      "id": 31,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcd_restarts_range')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_etcd_restarts_range'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Restarts",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Pending pods in kube-scheduler queue.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "axisSoftMax": 5
+          },
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 213
+      },
+      "id": 32,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_schedulerPendingPodsCount_range')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER\n    AND label_values ? '__measurements_schedulerPendingPodsCount_range'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Scheduler Pending Pods",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": [
+    "pipelines",
+    "version-comparison",
+    "performance"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "grafana-postgresql-datasource",
+          "value": "grafana-postgresql-datasource"
+        },
+        "description": "PostgreSQL datasource for pipeline metrics",
+        "label": "Datasource",
+        "name": "datasource",
+        "query": "grafana-postgresql-datasource",
+        "regex": ".*grafana-postgresql-datasource.*",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "Standard",
+          "value": "423"
+        },
+        "description": "Pipeline deployment variant (each maps to a separate Horreum test ID).",
+        "includeAll": false,
+        "label": "Variant",
+        "multi": false,
+        "name": "variant",
+        "options": [
+          {
+            "selected": true,
+            "text": "Standard",
+            "value": "423"
+          },
+          {
+            "selected": false,
+            "text": "HA - Deployments",
+            "value": "419"
+          },
+          {
+            "selected": false,
+            "text": "HA - StatefulSets",
+            "value": "421"
+          },
+          {
+            "selected": false,
+            "text": "QBT (non-HA)",
+            "value": "422"
+          },
+          {
+            "selected": false,
+            "text": "HA + QBT",
+            "value": "420"
+          }
+        ],
+        "query": "Standard : 423,HA - Deployments : 419,HA - StatefulSets : 421,QBT (non-HA) : 422,HA + QBT : 420",
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Select versions to compare. Use All to include every version.",
+        "includeAll": true,
+        "label": "Version",
+        "multi": true,
+        "name": "version",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "1",
+          "value": "1"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Select a single concurrency level to compare versions at.",
+        "includeAll": false,
+        "label": "Concurrency",
+        "multi": false,
+        "name": "concurrency",
+        "query": "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE (\n  horreum_testid = ${variant}::INTEGER\n  OR (\n    horreum_testid = 391\n    AND (\n      (${variant}::INTEGER = 423\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 419\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 421\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'\n        AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))\n      OR (${variant}::INTEGER = 422\n        AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n      OR (${variant}::INTEGER = 420\n        AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true\n        AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'\n        AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)\n    )\n  )\n)\n AND $__timeFilter(start) AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency",
+        "refresh": 2,
+        "sort": 3,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-14d",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Pipelines Version Comparison (v2)",
+  "uid": "Pipelines_Version_Comparison_v2"
+}

--- a/config/grafonnet-workdir/generated/results-comparison-dashboard.json
+++ b/config/grafonnet-workdir/generated/results-comparison-dashboard.json
@@ -1,0 +1,2353 @@
+{
+  "description": "Side-by-side comparison of two Tekton Results versions. Test ID 425.",
+  "editable": true,
+  "graphTooltip": 2,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "title": "PipelineRun Ingestion",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the Results watcher ingests completed PipelineRuns (records/sec). Higher indicates faster ingestion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_throughput')::DOUBLE PRECISION) AS throughput\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_ingestion_throughput'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'throughput' AS metric,\n  throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Ingestion Throughput — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the Results watcher ingests completed PipelineRuns (records/sec). Higher indicates faster ingestion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_throughput')::DOUBLE PRECISION) AS throughput\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_ingestion_throughput'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'throughput' AS metric,\n  throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Ingestion Throughput — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total wall-clock time for the Results watcher to ingest all completed PipelineRuns. Lower means the watcher kept up with the pipeline creation rate.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_duration')::DOUBLE PRECISION) AS duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_ingestion_duration'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'duration' AS metric,\n  duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Ingestion Duration — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total wall-clock time for the Results watcher to ingest all completed PipelineRuns. Lower means the watcher kept up with the pipeline creation rate.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_duration')::DOUBLE PRECISION) AS duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_ingestion_duration'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'duration' AS metric,\n  duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Ingestion Duration — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of PipelineRun records successfully persisted to the Results API database.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_count_stored_true')::DOUBLE PRECISION) AS stored_ok\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_ingestion_count_stored_true'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_ok' AS metric,\n  stored_ok AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Stored Successfully — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of PipelineRun records successfully persisted to the Results API database.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_count_stored_true')::DOUBLE PRECISION) AS stored_ok\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_ingestion_count_stored_true'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_ok' AS metric,\n  stored_ok AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Stored Successfully — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of PipelineRun records that failed to persist. Non-zero indicates API errors, DB write failures, or resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_count_stored_false')::DOUBLE PRECISION) AS stored_fail\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_ingestion_count_stored_false'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_fail' AS metric,\n  stored_fail AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Store Failures — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of PipelineRun records that failed to persist. Non-zero indicates API errors, DB write failures, or resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_count_stored_false')::DOUBLE PRECISION) AS stored_fail\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_ingestion_count_stored_false'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_fail' AS metric,\n  stored_fail AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Store Failures — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 10,
+      "title": "TaskRun Ingestion",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the Results watcher ingests completed TaskRuns (records/sec). Each PipelineRun contains 5 tasks × 10 steps.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_TaskRuns_ingestion_throughput')::DOUBLE PRECISION) AS throughput\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_ingestion_throughput'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'throughput' AS metric,\n  throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Ingestion Throughput — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the Results watcher ingests completed TaskRuns (records/sec). Each PipelineRun contains 5 tasks × 10 steps.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_TaskRuns_ingestion_throughput')::DOUBLE PRECISION) AS throughput\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_ingestion_throughput'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'throughput' AS metric,\n  throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Ingestion Throughput — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total wall-clock time for the Results watcher to ingest all completed TaskRuns.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_TaskRuns_ingestion_duration')::DOUBLE PRECISION) AS duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_ingestion_duration'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'duration' AS metric,\n  duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Ingestion Duration — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total wall-clock time for the Results watcher to ingest all completed TaskRuns.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_TaskRuns_ingestion_duration')::DOUBLE PRECISION) AS duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_ingestion_duration'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'duration' AS metric,\n  duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Ingestion Duration — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of TaskRun records successfully persisted to the Results API database.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_TaskRuns_ingestion_count_stored_true')::DOUBLE PRECISION) AS stored_ok\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_ingestion_count_stored_true'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_ok' AS metric,\n  stored_ok AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Stored Successfully — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of TaskRun records successfully persisted to the Results API database.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_TaskRuns_ingestion_count_stored_true')::DOUBLE PRECISION) AS stored_ok\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_ingestion_count_stored_true'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_ok' AS metric,\n  stored_ok AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Stored Successfully — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of TaskRun records that failed to persist. Non-zero indicates API errors, DB write failures, or resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_TaskRuns_ingestion_count_stored_false')::DOUBLE PRECISION) AS stored_fail\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_TaskRuns_ingestion_count_stored_false'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_fail' AS metric,\n  stored_fail AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Store Failures — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of TaskRun records that failed to persist. Non-zero indicates API errors, DB write failures, or resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_TaskRuns_ingestion_count_stored_false')::DOUBLE PRECISION) AS stored_fail\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_TaskRuns_ingestion_count_stored_false'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_fail' AS metric,\n  stored_fail AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Store Failures — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 19,
+      "title": "Results API",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Latency of the Results API /record endpoint under Locust load test (100 users, 10 spawn/sec, 15 min). Shows mean and worst-case response time.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 67
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_ResultsAPI_record_latency_avg')::DOUBLE PRECISION) AS latency_avg,\n    AVG((label_values->>'__results_ResultsAPI_record_latency_max')::DOUBLE PRECISION) AS latency_max\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_ResultsAPI_record_latency_avg'\n    AND label_values ? '__results_ResultsAPI_record_latency_max'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_avg' AS metric,\n  latency_avg AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_max' AS metric,\n  latency_max AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/record Latency — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Latency of the Results API /record endpoint under Locust load test (100 users, 10 spawn/sec, 15 min). Shows mean and worst-case response time.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 67
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_ResultsAPI_record_latency_avg')::DOUBLE PRECISION) AS latency_avg,\n    AVG((label_values->>'__results_ResultsAPI_record_latency_max')::DOUBLE PRECISION) AS latency_max\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_ResultsAPI_record_latency_avg'\n    AND label_values ? '__results_ResultsAPI_record_latency_max'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_avg' AS metric,\n  latency_avg AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_max' AS metric,\n  latency_max AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/record Latency — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Sustained requests per second to the Results API /record endpoint during Locust load test. Measures single-record fetch throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 75
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_ResultsAPI_record_rps')::DOUBLE PRECISION) AS rps\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_ResultsAPI_record_rps'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'rps' AS metric,\n  rps AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/record RPS — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Sustained requests per second to the Results API /record endpoint during Locust load test. Measures single-record fetch throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 75
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_ResultsAPI_record_rps')::DOUBLE PRECISION) AS rps\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_ResultsAPI_record_rps'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'rps' AS metric,\n  rps AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/record RPS — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Latency of the Results API /records (list) endpoint under Locust load test. Typically higher than /record due to pagination and result set construction.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 83
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_ResultsAPI_records_latency_avg')::DOUBLE PRECISION) AS latency_avg,\n    AVG((label_values->>'__results_ResultsAPI_records_latency_max')::DOUBLE PRECISION) AS latency_max\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_ResultsAPI_records_latency_avg'\n    AND label_values ? '__results_ResultsAPI_records_latency_max'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_avg' AS metric,\n  latency_avg AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_max' AS metric,\n  latency_max AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/records Latency — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Latency of the Results API /records (list) endpoint under Locust load test. Typically higher than /record due to pagination and result set construction.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 83
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_ResultsAPI_records_latency_avg')::DOUBLE PRECISION) AS latency_avg,\n    AVG((label_values->>'__results_ResultsAPI_records_latency_max')::DOUBLE PRECISION) AS latency_max\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_ResultsAPI_records_latency_avg'\n    AND label_values ? '__results_ResultsAPI_records_latency_max'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_avg' AS metric,\n  latency_avg AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_max' AS metric,\n  latency_max AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/records Latency — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Sustained requests per second to the Results API /records (list) endpoint during Locust load test. Measures bulk-fetch throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 91
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_ResultsAPI_records_rps')::DOUBLE PRECISION) AS rps\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_ResultsAPI_records_rps'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'rps' AS metric,\n  rps AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/records RPS — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Sustained requests per second to the Results API /records (list) endpoint during Locust load test. Measures bulk-fetch throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 91
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_ResultsAPI_records_rps')::DOUBLE PRECISION) AS rps\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_ResultsAPI_records_rps'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'rps' AS metric,\n  rps AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/records RPS — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 99
+      },
+      "id": 28,
+      "title": "Results Watcher & API Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "CPU of the tekton-results-watcher Pod (cores). Watches for completed PipelineRuns/TaskRuns and persists them to the Results API.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 100
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonResultsWatcher_cpu_max'\n    AND label_values ? '__measurements_tektonResultsWatcher_cpu_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max' AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean' AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Watcher CPU — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "CPU of the tekton-results-watcher Pod (cores). Watches for completed PipelineRuns/TaskRuns and persists them to the Results API.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 100
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonResultsWatcher_cpu_max'\n    AND label_values ? '__measurements_tektonResultsWatcher_cpu_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max' AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean' AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Watcher CPU — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Memory (RSS) of the tekton-results-watcher Pod. High memory may indicate large watch caches or slow GC under high ingestion load.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 108
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonResultsWatcher_memory_max'\n    AND label_values ? '__measurements_tektonResultsWatcher_memory_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max' AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean' AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Watcher Memory — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Memory (RSS) of the tekton-results-watcher Pod. High memory may indicate large watch caches or slow GC under high ingestion load.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 108
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonResultsWatcher_memory_max'\n    AND label_values ? '__measurements_tektonResultsWatcher_memory_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max' AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean' AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Watcher Memory — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "CPU of the tekton-results-api Pod (cores). Serves the Results REST API hit by the Locust load test.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 116
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_tektonResultsApi_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonResultsApi_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonResultsApi_cpu_max'\n    AND label_values ? '__measurements_tektonResultsApi_cpu_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max' AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean' AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "CPU of the tekton-results-api Pod (cores). Serves the Results REST API hit by the Locust load test.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 116
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_tektonResultsApi_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonResultsApi_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonResultsApi_cpu_max'\n    AND label_values ? '__measurements_tektonResultsApi_cpu_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max' AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean' AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Memory (RSS) of the tekton-results-api Pod. High memory may indicate query result caching or connection pool growth under Locust load.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 124
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_tektonResultsApi_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonResultsApi_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_tektonResultsApi_memory_max'\n    AND label_values ? '__measurements_tektonResultsApi_memory_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max' AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean' AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Memory (RSS) of the tekton-results-api Pod. High memory may indicate query result caching or connection pool growth under Locust load.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 124
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_tektonResultsApi_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonResultsApi_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_tektonResultsApi_memory_max'\n    AND label_values ? '__measurements_tektonResultsApi_memory_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max' AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean' AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 132
+      },
+      "id": 37,
+      "title": "Pipeline Performance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average wall-clock time from PipelineRun creation to completion. Each pipeline has 5 tasks × 10 steps × 15 log lines. Includes scheduling, execution, and signing overhead.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 133
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration' AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Duration (avg) — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average wall-clock time from PipelineRun creation to completion. Each pipeline has 5 tasks × 10 steps × 15 log lines. Includes scheduling, execution, and signing overhead.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 133
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration' AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Duration (avg) — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total PipelineRuns that completed successfully. The test creates PRs at a constant rate with 30 concurrent; all should succeed.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 141
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded' AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Succeeded — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total PipelineRuns that completed successfully. The test creates PRs at a constant rate with 30 concurrent; all should succeed.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 141
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded' AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Succeeded — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 149
+      },
+      "id": 42,
+      "title": "Cluster & Infrastructure",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster CPU usage rate (cores) across all nodes. Reflects the combined load of pipeline execution, signing, ingestion, and Locust testing.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 150
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu' AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster CPU — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster CPU usage rate (cores) across all nodes. Reflects the combined load of pipeline execution, signing, ingestion, and Locust testing.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 150
+      },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu' AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster CPU — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster RSS memory across all nodes during the test.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 158
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem' AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Memory — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster RSS memory across all nodes during the test.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 158
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem' AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Memory — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 166
+      },
+      "id": 47,
+      "title": "etcd",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd MVCC database total size. Reflects Kubernetes object storage growth from PipelineRun/TaskRun creation.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 167
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total' AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd DB Size — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd MVCC database total size. Reflects Kubernetes object storage growth from PipelineRun/TaskRun creation.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 167
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total' AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd DB Size — ${version2}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd request latency. High latency indicates etcd is under pressure from the volume of Kubernetes API operations.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 175
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version1}'\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration' AS metric,\n  req_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Request Duration — ${version1}",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd request latency. High latency indicates etcd is under pressure from the volume of Kubernetes API operations.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 175
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version2}'\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration' AS metric,\n  req_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Request Duration — ${version2}",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": [
+    "results",
+    "comparison",
+    "performance"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "grafana-postgresql-datasource",
+          "value": "grafana-postgresql-datasource"
+        },
+        "description": "PostgreSQL datasource for Results metrics",
+        "label": "Datasource",
+        "name": "datasource",
+        "query": "grafana-postgresql-datasource",
+        "regex": ".*grafana-postgresql-datasource.*",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "nightly",
+          "value": "nightly"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Version 1 for comparison.",
+        "includeAll": false,
+        "label": "Version 1",
+        "multi": false,
+        "name": "version1",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE horreum_testid = 425 AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "1.22",
+          "value": "1.22"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Version 2 for comparison.",
+        "includeAll": false,
+        "label": "Version 2",
+        "multi": false,
+        "name": "version2",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE horreum_testid = 425 AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Results Comparison Dashboard",
+  "uid": "Results_Comparison"
+}

--- a/config/grafonnet-workdir/generated/results-dashboard.json
+++ b/config/grafonnet-workdir/generated/results-dashboard.json
@@ -1,0 +1,1352 @@
+{
+  "description": "Tekton Results performance — watcher ingestion latency, API load testing, and component resource usage across versions. Test ID 425.",
+  "editable": true,
+  "graphTooltip": 2,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "title": "PipelineRun Ingestion",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the Results watcher ingests completed PipelineRuns into the Results API (records/sec). Higher indicates faster ingestion. Measured during the signing+ingestion phase of the test.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_throughput')::DOUBLE PRECISION) AS throughput\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_PipelineRuns_ingestion_throughput'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'throughput @ ' || version || ' / c' || concurrency AS metric,\n  throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Ingestion Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total wall-clock time for the Results watcher to ingest all completed PipelineRuns. Lower means the watcher kept up with the pipeline creation rate.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_duration')::DOUBLE PRECISION) AS duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_PipelineRuns_ingestion_duration'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'duration @ ' || version || ' / c' || concurrency AS metric,\n  duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Ingestion Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of PipelineRun records the Results watcher successfully persisted to the Results API database.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_count_stored_true')::DOUBLE PRECISION) AS stored_ok\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_PipelineRuns_ingestion_count_stored_true'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_ok @ ' || version || ' / c' || concurrency AS metric,\n  stored_ok AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Stored Successfully",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of PipelineRun records the Results watcher failed to persist. Non-zero values indicate API errors, DB write failures, or resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_ingestion_count_stored_false')::DOUBLE PRECISION) AS stored_fail\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_PipelineRuns_ingestion_count_stored_false'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_fail @ ' || version || ' / c' || concurrency AS metric,\n  stored_fail AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Store Failures",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "title": "TaskRun Ingestion",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the Results watcher ingests completed TaskRuns into the Results API (records/sec). Each PipelineRun contains multiple TaskRuns (5 tasks × steps).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_ingestion_throughput')::DOUBLE PRECISION) AS throughput\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_TaskRuns_ingestion_throughput'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'throughput @ ' || version || ' / c' || concurrency AS metric,\n  throughput AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Ingestion Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total wall-clock time for the Results watcher to ingest all completed TaskRuns.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_ingestion_duration')::DOUBLE PRECISION) AS duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_TaskRuns_ingestion_duration'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'duration @ ' || version || ' / c' || concurrency AS metric,\n  duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Ingestion Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of TaskRun records the Results watcher successfully persisted to the Results API database.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_ingestion_count_stored_true')::DOUBLE PRECISION) AS stored_ok\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_TaskRuns_ingestion_count_stored_true'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_ok @ ' || version || ' / c' || concurrency AS metric,\n  stored_ok AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Stored Successfully",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of TaskRun records the Results watcher failed to persist. Non-zero values indicate API errors, DB write failures, or resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_TaskRuns_ingestion_count_stored_false')::DOUBLE PRECISION) AS stored_fail\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_TaskRuns_ingestion_count_stored_false'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'stored_fail @ ' || version || ' / c' || concurrency AS metric,\n  stored_fail AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Store Failures",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 11,
+      "title": "Results API",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Latency of the Results API /record endpoint under Locust load test (100 users, 10 spawn/sec, 15 min).\n- **latency_avg**: mean response time\n- **latency_max**: worst-case response time",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_ResultsAPI_record_latency_avg')::DOUBLE PRECISION) AS latency_avg,\n    AVG((label_values->>'__results_ResultsAPI_record_latency_max')::DOUBLE PRECISION) AS latency_max\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_ResultsAPI_record_latency_avg'\n    AND label_values ? '__results_ResultsAPI_record_latency_max'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_avg @ ' || version || ' / c' || concurrency AS metric,\n  latency_avg AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_max @ ' || version || ' / c' || concurrency AS metric,\n  latency_max AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/record Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Sustained requests per second to the Results API /record endpoint during the Locust load test. Measures single-record fetch throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_ResultsAPI_record_rps')::DOUBLE PRECISION) AS rps\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_ResultsAPI_record_rps'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'rps @ ' || version || ' / c' || concurrency AS metric,\n  rps AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/record RPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Latency of the Results API /records (list) endpoint under Locust load test.\n- **latency_avg**: mean response time\n- **latency_max**: worst-case response time",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_ResultsAPI_records_latency_avg')::DOUBLE PRECISION) AS latency_avg,\n    AVG((label_values->>'__results_ResultsAPI_records_latency_max')::DOUBLE PRECISION) AS latency_max\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_ResultsAPI_records_latency_avg'\n    AND label_values ? '__results_ResultsAPI_records_latency_max'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_avg @ ' || version || ' / c' || concurrency AS metric,\n  latency_avg AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'latency_max @ ' || version || ' / c' || concurrency AS metric,\n  latency_max AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/records Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Sustained requests per second to the Results API /records (list) endpoint during the Locust load test. Measures bulk-fetch throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_ResultsAPI_records_rps')::DOUBLE PRECISION) AS rps\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_ResultsAPI_records_rps'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'rps @ ' || version || ' / c' || concurrency AS metric,\n  rps AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/records RPS",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 16,
+      "title": "Results Watcher & API Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "CPU usage of the tekton-results-watcher Pod (cores). The watcher watches for completed PipelineRuns/TaskRuns and persists them to the Results API.\n- **cpu_mean**: average over test duration\n- **cpu_max**: peak usage",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_tektonResultsWatcher_cpu_max'\n    AND label_values ? '__measurements_tektonResultsWatcher_cpu_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max @ ' || version || ' / c' || concurrency AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean @ ' || version || ' / c' || concurrency AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Watcher CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Memory (RSS) of the tekton-results-watcher Pod. High memory may indicate large watch caches or slow GC under high ingestion load.\n- **mem_mean**: average over test duration\n- **mem_max**: peak usage",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonResultsWatcher_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_tektonResultsWatcher_memory_max'\n    AND label_values ? '__measurements_tektonResultsWatcher_memory_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max @ ' || version || ' / c' || concurrency AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean @ ' || version || ' / c' || concurrency AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Watcher Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "CPU usage of the tekton-results-api Pod (cores). Serves the Results REST API hit by the Locust load test (/record, /records endpoints).\n- **cpu_mean**: average over test duration\n- **cpu_max**: peak usage",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonResultsApi_cpu_max')::DOUBLE PRECISION) AS cpu_max,\n    AVG((label_values->>'__measurements_tektonResultsApi_cpu_mean')::DOUBLE PRECISION) AS cpu_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_tektonResultsApi_cpu_max'\n    AND label_values ? '__measurements_tektonResultsApi_cpu_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_max @ ' || version || ' / c' || concurrency AS metric,\n  cpu_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cpu_mean @ ' || version || ' / c' || concurrency AS metric,\n  cpu_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Memory (RSS) of the tekton-results-api Pod. High memory may indicate query result caching or connection pool growth under Locust load.\n- **mem_mean**: average over test duration\n- **mem_max**: peak usage",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonResultsApi_memory_max')::DOUBLE PRECISION) AS mem_max,\n    AVG((label_values->>'__measurements_tektonResultsApi_memory_mean')::DOUBLE PRECISION) AS mem_mean\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_tektonResultsApi_memory_max'\n    AND label_values ? '__measurements_tektonResultsApi_memory_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_max @ ' || version || ' / c' || concurrency AS metric,\n  mem_max AS value\nFROM daily_agg\n\n\nUNION ALL\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'mem_mean @ ' || version || ' / c' || concurrency AS metric,\n  mem_mean AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 68
+      },
+      "id": 21,
+      "title": "Pipeline Performance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average wall-clock time from PipelineRun creation to completion. Each pipeline has 5 tasks × 10 steps × 15 log lines. Includes scheduling, execution, and signing overhead.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION) AS pr_duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_duration @ ' || version || ' / c' || concurrency AS metric,\n  pr_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Duration (avg)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total PipelineRuns that completed successfully. The test creates PRs at a constant rate with 30 concurrent; all should succeed.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION) AS pr_succeeded\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'pr_succeeded @ ' || version || ' / c' || concurrency AS metric,\n  pr_succeeded AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Succeeded",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "id": 24,
+      "title": "Cluster & Infrastructure",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster CPU usage rate (cores) across all nodes during the test. Reflects the combined load of pipelines execution, signing, ingestion, and Locust testing.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 86
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION) AS cluster_cpu\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_cpu @ ' || version || ' / c' || concurrency AS metric,\n  cluster_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster RSS memory across all nodes during the test.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 86
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION) AS cluster_mem\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'cluster_mem @ ' || version || ' / c' || concurrency AS metric,\n  cluster_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean CPU of the Tekton Pipelines controller. Handles PipelineRun/TaskRun reconciliation. Higher values indicate more reconciliation overhead.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 94
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_cpu_mean')::DOUBLE PRECISION) AS ctrl_cpu\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_tektonPipelinesController_cpu_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ctrl_cpu @ ' || version || ' / c' || concurrency AS metric,\n  ctrl_cpu AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Pipelines Controller CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean memory (RSS) of the Tekton Pipelines controller. Growth may indicate large informer caches from many concurrent PipelineRuns.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 94
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_tektonPipelinesController_memory_mean')::DOUBLE PRECISION) AS ctrl_mem\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_tektonPipelinesController_memory_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'ctrl_mem @ ' || version || ' / c' || concurrency AS metric,\n  ctrl_mem AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Pipelines Controller Memory",
+      "type": "timeseries"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 102
+      },
+      "id": 29,
+      "title": "etcd",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd MVCC database total size. Reflects the cumulative Kubernetes object storage. Rapid growth during the test indicates high PipelineRun/TaskRun creation rate.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 103
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION) AS db_total\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'db_total @ ' || version || ' / c' || concurrency AS metric,\n  db_total AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd DB Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd request latency. High latency indicates etcd is under pressure from the volume of Kubernetes API operations (PR/TR CRUD + status updates).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "gradientMode": "opacity",
+            "lineWidth": 2,
+            "pointSize": 6,
+            "showPoints": "always",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 103
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "time_series",
+          "rawSql": "WITH daily_agg AS (\n  SELECT\n    DATE_TRUNC('day', start) AS day,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,\n    AVG((label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION) AS req_duration\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END = '${version}'\n    AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)\n\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n  GROUP BY day, version, concurrency\n)\n\nSELECT\n  EXTRACT(EPOCH FROM day) AS time,\n  'req_duration @ ' || version || ' / c' || concurrency AS metric,\n  req_duration AS value\nFROM daily_agg\n\n\nORDER BY time, metric;\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Request Duration",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": [
+    "results",
+    "performance"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "grafana-postgresql-datasource",
+          "value": "grafana-postgresql-datasource"
+        },
+        "description": "PostgreSQL datasource for Results metrics",
+        "label": "Datasource",
+        "name": "datasource",
+        "query": "grafana-postgresql-datasource",
+        "regex": ".*grafana-postgresql-datasource.*",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "nightly",
+          "value": "nightly"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Filter by deployment version.",
+        "includeAll": false,
+        "label": "Version",
+        "multi": false,
+        "name": "version",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE horreum_testid = 425 AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Filter by concurrency level.",
+        "includeAll": true,
+        "label": "Concurrency",
+        "multi": true,
+        "name": "concurrency",
+        "query": "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE horreum_testid = 425 AND $__timeFilter(start) AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency",
+        "refresh": 2,
+        "sort": 3,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Results Performance Dashboard",
+  "uid": "Results_Performance"
+}

--- a/config/grafonnet-workdir/generated/results-version-comparison-v2.json
+++ b/config/grafonnet-workdir/generated/results-version-comparison-v2.json
@@ -1,0 +1,2647 @@
+{
+  "description": "Daily side-by-side version comparison of Tekton Results ingestion, API performance, and component resource usage. Test ID 425.",
+  "editable": true,
+  "graphTooltip": 2,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "title": "PipelineRun Ingestion",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the Results watcher ingests completed PipelineRuns (records/sec). Higher indicates faster ingestion. Compare across versions to detect watcher performance regressions.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_ingestion_throughput')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_PipelineRuns_ingestion_throughput'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Ingestion Throughput",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total wall-clock time for the Results watcher to ingest all completed PipelineRuns. Lower means the watcher kept up with the pipeline creation rate.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_ingestion_duration')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_PipelineRuns_ingestion_duration'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Ingestion Duration",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of PipelineRun records successfully persisted to the Results API database per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 4,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_ingestion_count_stored_true')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_PipelineRuns_ingestion_count_stored_true'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Stored Successfully",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of PipelineRun records that failed to persist. Non-zero values indicate API errors, DB write failures, or resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 5,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_ingestion_count_stored_false')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_PipelineRuns_ingestion_count_stored_false'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PR Store Failures",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 6,
+      "title": "TaskRun Ingestion",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the Results watcher ingests completed TaskRuns (records/sec). Each PipelineRun contains 5 tasks × 10 steps.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 7,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_ingestion_throughput')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_TaskRuns_ingestion_throughput'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Ingestion Throughput",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total wall-clock time for the Results watcher to ingest all completed TaskRuns.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 8,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_ingestion_duration')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_TaskRuns_ingestion_duration'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Ingestion Duration",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of TaskRun records successfully persisted to the Results API database per version per day.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 9,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_ingestion_count_stored_true')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_TaskRuns_ingestion_count_stored_true'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Stored Successfully",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Number of TaskRun records that failed to persist. Non-zero values indicate API errors, DB write failures, or resource exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 10,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_TaskRuns_ingestion_count_stored_false')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_TaskRuns_ingestion_count_stored_false'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "TR Store Failures",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 11,
+      "title": "Results API",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average response time of the Results API /record endpoint under Locust load test (100 users, 10 spawn/sec, 15 min). Measures single-record fetch latency.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 67
+      },
+      "id": 12,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_ResultsAPI_record_latency_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_ResultsAPI_record_latency_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/record Latency (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Sustained requests per second to the Results API /record endpoint during Locust load test. Higher is better — indicates the API can handle more concurrent fetch requests.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
+      "id": 13,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_ResultsAPI_record_rps')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_ResultsAPI_record_rps'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/record RPS",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average response time of the Results API /records (list) endpoint under Locust load test. Typically higher than /record due to pagination and result set construction.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 83
+      },
+      "id": 14,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_ResultsAPI_records_latency_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_ResultsAPI_records_latency_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/records Latency (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Sustained requests per second to the Results API /records (list) endpoint during Locust load test. Measures bulk-fetch throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 91
+      },
+      "id": 15,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_ResultsAPI_records_rps')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_ResultsAPI_records_rps'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "/records RPS",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 99
+      },
+      "id": 16,
+      "title": "Results Watcher & API Server",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean CPU of the tekton-results-watcher Pod (cores). The watcher watches for completed PipelineRuns/TaskRuns and persists them to the Results API.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 100
+      },
+      "id": 17,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonResultsWatcher_cpu_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__measurements_tektonResultsWatcher_cpu_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Watcher CPU (mean)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean memory (RSS) of the tekton-results-watcher Pod. High memory may indicate large watch caches or slow GC under high ingestion load.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 108
+      },
+      "id": 18,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonResultsWatcher_memory_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__measurements_tektonResultsWatcher_memory_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Watcher Memory (mean)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean CPU of the tekton-results-api Pod (cores). Serves the Results REST API hit by the Locust load test.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 116
+      },
+      "id": 19,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonResultsApi_cpu_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__measurements_tektonResultsApi_cpu_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server CPU (mean)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean memory (RSS) of the tekton-results-api Pod. High memory may indicate query result caching or connection pool growth under Locust load.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 124
+      },
+      "id": 20,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_tektonResultsApi_memory_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__measurements_tektonResultsApi_memory_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "API Server Memory (mean)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 132
+      },
+      "id": 21,
+      "title": "Pipeline Performance",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Average wall-clock time from PipelineRun creation to completion. Each pipeline has 5 tasks × 10 steps × 15 log lines. Includes scheduling, execution, and signing overhead.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 133
+      },
+      "id": 22,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_duration_avg')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_PipelineRuns_duration_avg'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Duration (avg)",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Total PipelineRuns that completed successfully. The test creates PRs at a constant rate with 30 concurrent; all should succeed.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 141
+      },
+      "id": 23,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__results_PipelineRuns_count_succeeded')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__results_PipelineRuns_count_succeeded'\n)\nSELECT day, version, SUM(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "PipelineRun Succeeded",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 149
+      },
+      "id": 24,
+      "title": "Cluster & Infrastructure",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster CPU usage rate (cores) across all nodes. Reflects the combined load of pipeline execution, signing, ingestion, and Locust testing.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 150
+      },
+      "id": 25,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_clusterCpuUsageSecondsTotalRate_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__measurements_clusterCpuUsageSecondsTotalRate_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster CPU",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean total cluster RSS memory across all nodes during the test.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 158
+      },
+      "id": 26,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_clusterMemoryUsageRssTotal_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__measurements_clusterMemoryUsageRssTotal_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Memory",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 166
+      },
+      "id": 27,
+      "title": "etcd",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd MVCC database total size. Reflects Kubernetes object storage growth from PipelineRun/TaskRun creation.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 167
+      },
+      "id": 28,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcdMvccDbTotalSizeInBytesAverage_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd DB Size",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${datasource}"
+      },
+      "description": "Mean etcd request latency. High latency indicates etcd is under pressure from the volume of Kubernetes API operations.",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 175
+      },
+      "id": 29,
+      "options": {
+        "barWidth": 0.84999999999999998,
+        "groupWidth": 0.55000000000000004,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "v11.4.0",
+      "targets": [
+        {
+          "format": "table",
+          "rawSql": "WITH daily AS (\n  SELECT\n    TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,\n    DATE_TRUNC('day', start) AS day_date,\n    CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version,\n    (label_values->>'__measurements_etcdRequestDurationSecondsAverage_mean')::DOUBLE PRECISION AS val\n  FROM data\n  WHERE horreum_testid = 425\n    AND $__timeFilter(start)\n    AND CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END IN ($version)\n    AND label_values ? '__measurements_etcdRequestDurationSecondsAverage_mean'\n)\nSELECT day, version, AVG(val) AS value\nFROM daily\nGROUP BY day, version\nORDER BY MIN(day_date),\n  CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,\n  version ASC\n",
+          "refId": "A"
+        }
+      ],
+      "title": "etcd Request Duration",
+      "transformations": [
+        {
+          "id": "groupingToMatrix",
+          "options": {
+            "columnField": "version",
+            "rowField": "day",
+            "valueField": "value"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "indexByName": {
+              "1.0": 2,
+              "1.1": 3,
+              "1.10": 12,
+              "1.11": 13,
+              "1.12": 14,
+              "1.13": 15,
+              "1.14": 16,
+              "1.15": 17,
+              "1.16": 18,
+              "1.17": 19,
+              "1.18": 20,
+              "1.19": 21,
+              "1.2": 4,
+              "1.20": 22,
+              "1.21": 23,
+              "1.22": 24,
+              "1.23": 25,
+              "1.24": 26,
+              "1.25": 27,
+              "1.26": 28,
+              "1.27": 29,
+              "1.28": 30,
+              "1.29": 31,
+              "1.3": 5,
+              "1.30": 32,
+              "1.31": 33,
+              "1.32": 34,
+              "1.33": 35,
+              "1.34": 36,
+              "1.35": 37,
+              "1.36": 38,
+              "1.37": 39,
+              "1.38": 40,
+              "1.39": 41,
+              "1.4": 6,
+              "1.40": 42,
+              "1.41": 43,
+              "1.42": 44,
+              "1.43": 45,
+              "1.44": 46,
+              "1.45": 47,
+              "1.46": 48,
+              "1.47": 49,
+              "1.48": 50,
+              "1.49": 51,
+              "1.5": 7,
+              "1.50": 52,
+              "1.6": 8,
+              "1.7": 9,
+              "1.8": 10,
+              "1.9": 11,
+              "day\\version": 0,
+              "nightly": 1
+            }
+          }
+        }
+      ],
+      "type": "barchart"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "tags": [
+    "results",
+    "version-comparison",
+    "performance"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "grafana-postgresql-datasource",
+          "value": "grafana-postgresql-datasource"
+        },
+        "description": "PostgreSQL datasource for Results metrics",
+        "label": "Datasource",
+        "name": "datasource",
+        "query": "grafana-postgresql-datasource",
+        "regex": ".*grafana-postgresql-datasource.*",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "${datasource}"
+        },
+        "description": "Select versions to compare. Use All to include every version.",
+        "includeAll": true,
+        "label": "Version",
+        "multi": true,
+        "name": "version",
+        "query": "SELECT DISTINCT CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END AS version FROM data WHERE horreum_testid = 425 AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC",
+        "refresh": 2,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-14d",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Results Version Comparison (v2)",
+  "uid": "Results_Version_Comparison_v2"
+}

--- a/config/grafonnet-workdir/src/chains-comparison-dashboard.jsonnet
+++ b/config/grafonnet-workdir/src/chains-comparison-dashboard.jsonnet
@@ -1,64 +1,40 @@
 local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/chains-common.libsonnet';
 
 local dashboard = grafonnet.dashboard;
 local timeSeries = grafonnet.panel.timeSeries;
 
-// ─── Constants ───────────────────────────────────────────────────────────────
-local testId = 418;
-local versionQuery = "SELECT DISTINCT (label_values->>'__deployment_version') AS __text FROM data WHERE horreum_testid = %g AND label_values ? '__deployment_version' AND (label_values->>'__deployment_version') IS NOT NULL AND (label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = false) AND label_values ? '__results_PipelineRuns_signing_throughput' ORDER BY __text" % testId;
+local versionExpr = common.versionExpr;
+local testIdPredicate = common.testIdPredicate;
+local datasourceVar = common.datasourceVar;
+local variantVar = common.variantVar;
 
-// ─── Template variables ─────────────────────────────────────────────────────
-local datasourceVar =
-  grafonnet.dashboard.variable.datasource.new(
-    'datasource',
-    'grafana-postgresql-datasource',
-  )
-  + grafonnet.dashboard.variable.datasource.withRegex('.*grafana-postgresql-datasource.*')
-  + grafonnet.dashboard.variable.custom.generalOptions.withLabel('Datasource')
-  + grafonnet.dashboard.variable.custom.generalOptions.withDescription('PostgreSQL datasource for Chains metrics')
-  + grafonnet.dashboard.variable.custom.generalOptions.withCurrent('grafana-postgresql-datasource');
+local versionQuery = "SELECT DISTINCT %s AS version FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testIdPredicate];
 
 local createVersionVar(name, label, defaultVersion) = {
   type: 'query',
   name: name,
   label: label,
-  description: '%s for comparison' % label,
+  description: '%s for comparison.' % label,
   datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
   query: versionQuery,
   multi: false,
   includeAll: false,
   current: { text: defaultVersion, value: defaultVersion },
-  refresh: 1,
-  sort: 4,
+  refresh: 2,
+  sort: 0,
 };
 
-local version1Var = createVersionVar('version1', 'Version 1', '1.22');
-local version2Var = createVersionVar('version2', 'Version 2', '1.21');
-
-local deployConfigVar = {
-  type: 'custom',
-  name: 'deploy_config',
-  label: 'Deployment Configuration',
-  description: 'Standard, HA, QBT, or HA+QBT.',
-  query: 'Standard : standard,HA : ha,QBT (non-HA) : qbt,HA + QBT : ha-qbt',
-  multi: false,
-  includeAll: false,
-  current: { text: 'Standard', value: 'standard' },
-  options: [
-    { text: 'Standard', value: 'standard', selected: true },
-    { text: 'HA', value: 'ha', selected: false },
-    { text: 'QBT (non-HA)', value: 'qbt', selected: false },
-    { text: 'HA + QBT', value: 'ha-qbt', selected: false },
-  ],
-};
+local version1Var = createVersionVar('version1', 'Version 1', 'nightly');
+local version2Var = createVersionVar('version2', 'Version 2', '1.23');
 
 local testTotalVar = {
   type: 'query',
   name: 'test_total',
   label: 'Test Total',
-  description: 'Filter by total PipelineRuns count (500, 1000, 1500).',
+  description: 'Filter by total PipelineRuns count (500, 1000).',
   datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
-  query: "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE horreum_testid = %g AND label_values ? '__parameters_test_total' ORDER BY test_total" % testId,
+  query: "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__parameters_test_total' ORDER BY test_total" % testIdPredicate,
   multi: true,
   includeAll: true,
   current: { text: 'All', value: '$__all' },
@@ -66,29 +42,13 @@ local testTotalVar = {
   sort: 3,
 };
 
-// ─── SQL predicates ─────────────────────────────────────────────────────────
-
 local versionPredicate(varName) = |||
-        AND label_values ? '__deployment_version'
-        AND (label_values->>'__deployment_version') = '${%s}'
-        AND label_values ? '__deployment_nightly'
-        AND (label_values->>'__deployment_nightly')::BOOLEAN = false
-||| % varName;
-
-local deployConfigPredicate = |||
-        AND (
-          ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
-          OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
-        )
-|||;
+        AND %s = '${%s}'
+||| % [versionExpr, varName];
 
 local testTotalPredicate = |||
         AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)
 |||;
-
-// ─── Query builders ─────────────────────────────────────────────────────────
 
 local createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields={}) =
   local baseFields = { [metricLabel]: fieldName };
@@ -105,7 +65,7 @@ local createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields
     |||
       SELECT
         EXTRACT(EPOCH FROM day) AS time,
-        '%s @ ' || test_total AS metric,
+        '%s @ t' || test_total AS metric,
         %s AS value
       FROM daily_agg
     ||| % [key, key]
@@ -120,9 +80,8 @@ local createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields
           (label_values->>'__parameters_test_total')::INTEGER AS test_total,
           %s
         FROM data
-        WHERE horreum_testid = %g
+        WHERE %s
           AND $__timeFilter(start)
-          %s
           %s
           %s
           AND %s
@@ -132,15 +91,13 @@ local createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields
       %s
 
       ORDER BY time, metric;
-    ||| % [fieldSelections, testId, testTotalPredicate, deployConfigPredicate, versionPredicate(versionVar), fieldConditions, selectStatements],
+    ||| % [fieldSelections, testIdPredicate, testTotalPredicate, versionPredicate(versionVar), fieldConditions, selectStatements],
     format: 'time_series',
     refId: 'A',
   };
 
-// ─── Panel builders ─────────────────────────────────────────────────────────
-
-local createComparisonPanel(title, fieldName, metricLabel, unit, gridX, gridY, gridW=12, gridH=8, versionVar='version1', additionalFields={}, description='') =
-  timeSeries.new('%s - v${%s}' % [title, versionVar])
+local comparisonPanel(title, fieldName, metricLabel, unit, gridX, gridY, gridW=12, gridH=8, versionVar='version1', additionalFields={}, description='', axisSoftMax=null) =
+  timeSeries.new('%s — ${%s}' % [title, versionVar])
   + timeSeries.queryOptions.withDatasource(type='grafana-postgresql-datasource', uid='${datasource}')
   + (if description != '' then timeSeries.panelOptions.withDescription(description) else {})
   + timeSeries.gridPos.withX(gridX)
@@ -148,49 +105,51 @@ local createComparisonPanel(title, fieldName, metricLabel, unit, gridX, gridY, g
   + timeSeries.gridPos.withW(gridW)
   + timeSeries.gridPos.withH(gridH)
   + timeSeries.fieldConfig.defaults.custom.withDrawStyle('line')
-  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(0)
+  + timeSeries.fieldConfig.defaults.custom.withLineWidth(2)
+  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(8)
+  + timeSeries.fieldConfig.defaults.custom.withGradientMode('opacity')
   + timeSeries.fieldConfig.defaults.custom.withSpanNulls(false)
   + timeSeries.fieldConfig.defaults.custom.withShowPoints('always')
-  + timeSeries.fieldConfig.defaults.custom.withPointSize(7)
+  + timeSeries.fieldConfig.defaults.custom.withPointSize(6)
   + timeSeries.standardOptions.withUnit(unit)
   + timeSeries.standardOptions.withMin(0)
+  + timeSeries.options.withTooltip({ mode: 'multi', sort: 'desc' })
+  + timeSeries.options.withLegend({ displayMode: 'list', placement: 'bottom', calcs: [] })
+  + (if axisSoftMax != null then { fieldConfig+: { defaults+: { custom+: { axisSoftMax: axisSoftMax } } } } else {})
   + timeSeries.queryOptions.withTargets([
     createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields),
   ]);
 
-local createPanelPair(title, fieldName, metricLabel, unit, y, additionalFields={}, description='') = [
-  createComparisonPanel(title, fieldName, metricLabel, unit, 0, y, versionVar='version1', additionalFields=additionalFields, description=description),
-  createComparisonPanel(title, fieldName, metricLabel, unit, 12, y, versionVar='version2', additionalFields=additionalFields, description=description),
+local panelPair(title, fieldName, metricLabel, unit, y, additionalFields={}, description='', axisSoftMax=null) = [
+  comparisonPanel(title, fieldName, metricLabel, unit, 0, y, versionVar='version1', additionalFields=additionalFields, description=description, axisSoftMax=axisSoftMax),
+  comparisonPanel(title, fieldName, metricLabel, unit, 12, y, versionVar='version2', additionalFields=additionalFields, description=description, axisSoftMax=axisSoftMax),
 ];
 
-local createRow(title, y) = {
+local row(title, y) = {
   type: 'row',
   title: title,
   gridPos: { h: 1, w: 24, x: 0, y: y },
 };
 
-// ─── Dashboard panels ───────────────────────────────────────────────────────
-
 local allPanels = [
-  // ── Signing Results ─────────────────────────────────────────
-  createRow('Signing Results', 0),
-] + createPanelPair(
+  row('Signing Results', 0),
+] + panelPair(
   'PipelineRun Signing Throughput',
   '__results_PipelineRuns_signing_throughput', 'pr_throughput', 'short', 1,
   description='PipelineRun signing throughput (signed runs per second). Higher is better.'
-) + createPanelPair(
+) + panelPair(
   'TaskRun Signing Throughput',
   '__results_TaskRuns_signing_throughput', 'tr_throughput', 'short', 9,
   description='TaskRun signing throughput (signed runs per second). Higher is better.'
-) + createPanelPair(
+) + panelPair(
   'PipelineRun Signing Duration',
   '__results_PipelineRuns_signing_duration', 'pr_sign_duration', 's', 17,
   description='Total wall-clock time of the PipelineRun signing window. Lower is better.'
-) + createPanelPair(
+) + panelPair(
   'TaskRun Signing Duration',
   '__results_TaskRuns_signing_duration', 'tr_sign_duration', 's', 25,
   description='Total wall-clock time of the TaskRun signing window. Lower is better.'
-) + createPanelPair(
+) + panelPair(
   'PipelineRun Signed Count',
   '__results_PipelineRuns_signing_count_signed_true', 'pr_signed', 'short', 33,
   additionalFields={
@@ -198,7 +157,7 @@ local allPanels = [
     pr_sign_failed: '__results_PipelineRuns_signing_count_signed_false',
   },
   description='PipelineRun signing outcome breakdown:\n- **pr_signed**: successfully signed\n- **pr_unsigned**: never signed\n- **pr_sign_failed**: signing failed'
-) + createPanelPair(
+) + panelPair(
   'TaskRun Signed Count',
   '__results_TaskRuns_signing_count_signed_true', 'tr_signed', 'short', 41,
   additionalFields={
@@ -208,119 +167,119 @@ local allPanels = [
   description='TaskRun signing outcome breakdown:\n- **tr_signed**: successfully signed\n- **tr_unsigned**: never signed\n- **tr_sign_failed**: signing failed'
 ) + [
 
-  // ── PipelineRun / TaskRun Counts ──────────────────────────────
-  createRow('PipelineRun & TaskRun Counts', 49),
-] + createPanelPair(
+  row('PipelineRun & TaskRun Counts', 49),
+] + panelPair(
   'PipelineRun Succeeded',
   '__results_PipelineRuns_count_succeeded', 'pr_succeeded', 'short', 50,
   description='Total PipelineRuns that completed successfully.'
-) + createPanelPair(
+) + panelPair(
   'PipelineRun Failed',
   '__results_PipelineRuns_count_failed', 'pr_failed', 'short', 58,
-  description='Total PipelineRuns that failed. Should be 0.'
-) + createPanelPair(
+  description='Failed PipelineRuns. Should be 0.',
+  axisSoftMax=5,
+) + panelPair(
   'TaskRun Succeeded',
   '__results_TaskRuns_count_succeeded', 'tr_succeeded', 'short', 66,
   description='Total TaskRuns that completed successfully.'
-) + createPanelPair(
+) + panelPair(
   'TaskRun Failed',
   '__results_TaskRuns_count_failed', 'tr_failed', 'short', 74,
-  description='Total TaskRuns that failed. Should be 0.'
+  description='Failed TaskRuns. Should be 0.',
+  axisSoftMax=5,
 ) + [
 
-  // ── Chains Controller Metrics ─────────────────────────────────
-  createRow('Chains Controller Metrics', 82),
-] + createPanelPair(
+  row('Chains Controller Metrics', 82),
+] + panelPair(
   'Chains Controller CPU Usage',
   '__measurements_tektonChainsController_cpu_mean', 'cpu_mean', 'short', 83,
   additionalFields={ cpu_max: '__measurements_tektonChainsController_cpu_max' },
   description='Tekton Chains controller CPU usage.\n- **cpu_mean**: average\n- **cpu_max**: peak'
-) + createPanelPair(
+) + panelPair(
   'Chains Controller Memory Usage',
   '__measurements_tektonChainsController_memory_mean', 'mem_mean', 'bytes', 91,
   additionalFields={ mem_max: '__measurements_tektonChainsController_memory_max' },
   description='Tekton Chains controller memory (RSS) usage.\n- **mem_mean**: average\n- **mem_max**: peak'
-) + createPanelPair(
+) + panelPair(
   'Chains Controller Workqueue Depth',
   '__measurements_tektonChainsControllerWorkqueueDepth_mean', 'wq_mean', 'short', 99,
   additionalFields={ wq_max: '__measurements_tektonChainsControllerWorkqueueDepth_max' },
   description='Chains controller workqueue depth.\n- **wq_mean**: average\n- **wq_max**: peak\n\nSustained high values indicate a signing bottleneck.'
-) + createPanelPair(
+) + panelPair(
   'Chains Controller Restarts',
   '__measurements_tektonChainsController_restarts_range', 'chains_restarts', 'short', 107,
-  description='Number of Chains controller Pod restarts. Should be 0.'
+  description='Chains controller Pod restarts. Should be 0.',
+  axisSoftMax=5,
 ) + [
 
-  // ── Cluster & API Server Metrics ──────────────────────────────
-  createRow('Cluster & API Server Metrics', 115),
-] + createPanelPair(
+  row('Cluster & API Server Metrics', 115),
+] + panelPair(
   'Cluster CPU Usage',
   '__measurements_clusterCpuUsageSecondsTotalRate_mean', 'cluster_cpu', 'short', 116,
   description='Mean total CPU usage rate across all cluster nodes.'
-) + createPanelPair(
+) + panelPair(
   'Cluster Memory Usage',
   '__measurements_clusterMemoryUsageRssTotal_mean', 'cluster_mem', 'bytes', 124,
   description='Mean total RSS memory usage across all cluster nodes.'
-) + createPanelPair(
-  'API Server CPU Usage (Mean)',
-  '__measurements_apiserver_cpu_mean', 'apiserver_cpu', 'short', 132,
+) + panelPair(
+  'API Server CPU (OpenShift / Kube)',
+  '__measurements_apiserver_cpu_mean', 'ocp_apiserver_cpu', 'short', 132,
   additionalFields={ kube_apiserver_cpu: '__measurements_kubeApiserver_cpu_mean' },
-  description='Mean CPU usage of API servers.\n- **apiserver_cpu**: openshift-apiserver\n- **kube_apiserver_cpu**: kube-apiserver'
-) + createPanelPair(
-  'API Server Memory Usage (Mean)',
-  '__measurements_apiserver_memory_mean', 'apiserver_mem', 'bytes', 140,
+  description='Mean CPU usage of API servers.'
+) + panelPair(
+  'API Server Memory (OpenShift / Kube)',
+  '__measurements_apiserver_memory_mean', 'ocp_apiserver_mem', 'bytes', 140,
   additionalFields={ kube_apiserver_mem: '__measurements_kubeApiserver_memory_mean' },
   description='Mean memory usage of API servers.'
 ) + [
 
-  // ── etcd Metrics ──────────────────────────────────────────────
-  createRow('etcd Metrics', 148),
-] + createPanelPair(
-  'etcd MVCC DB Size (Mean)',
+  row('etcd Metrics', 148),
+] + panelPair(
+  'etcd DB Size (total / in-use)',
   '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean', 'db_total', 'bytes', 149,
   additionalFields={ db_in_use: '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean' },
   description='Mean etcd MVCC database size.\n- **db_total**: total allocated\n- **db_in_use**: live data'
-) + createPanelPair(
-  'etcd Request Duration',
+) + panelPair(
+  'etcd Request Duration (mean / max)',
   '__measurements_etcdRequestDurationSecondsAverage_mean', 'req_duration_mean', 's', 157,
   additionalFields={ req_duration_max: '__measurements_etcdRequestDurationSecondsAverage_max' },
-  description='Mean and peak etcd request durations.\n- **req_duration_mean**: average latency\n- **req_duration_max**: worst-case latency'
+  description='etcd request latency.\n- **req_duration_mean**: average\n- **req_duration_max**: worst-case peak'
 ) + [
 
-  // ── Restarts ──────────────────────────────────────────────────
-  createRow('Component Restarts', 165),
-] + createPanelPair(
+  row('Component Restarts', 165),
+] + panelPair(
   'Infrastructure Restarts',
   '__measurements_etcd_restarts_range', 'etcd', 'short', 166,
   additionalFields={
     apiserver: '__measurements_apiserver_restarts_range',
     kube_apiserver: '__measurements_kubeApiserver_restarts_range',
   },
-  description='Restart counts for infrastructure components. All should be 0.'
-) + createPanelPair(
+  description='Restart counts for infrastructure components. All should be 0.',
+  axisSoftMax=5,
+) + panelPair(
   'Tekton Component Restarts',
   '__measurements_tektonPipelinesController_restarts_range', 'pipelines_ctrl', 'short', 174,
   additionalFields={
     pipelines_webhook: '__measurements_tektonPipelinesWebhook_restarts_range',
     proxy_webhook: '__measurements_tektonOperatorProxyWebhook_restarts_range',
   },
-  description='Restart counts for Tekton Pipelines components. All should be 0.'
-) + createPanelPair(
+  description='Restart counts for Tekton Pipelines components. All should be 0.',
+  axisSoftMax=5,
+) + panelPair(
   'Scheduler Pending Pods',
   '__measurements_schedulerPendingPodsCount_range', 'pending_pods', 'short', 182,
-  description='Range of pending pods in the kube-scheduler queue.'
+  description='Range of pending pods in the kube-scheduler queue.',
+  axisSoftMax=5,
 );
 
-// ─── Dashboard ──────────────────────────────────────────────────────────────
-
-dashboard.new('Chains Signing Performance Comparison Dashboard')
+dashboard.new('Chains Signing Performance Comparison')
 + dashboard.withUid('Chains_Signing_Performance_Comparison')
-+ dashboard.withDescription('Side-by-side comparison of Chains signing performance metrics across different released versions. Select two non-nightly versions to compare.')
-+ dashboard.time.withFrom('now-14d')
++ dashboard.withDescription('Side-by-side comparison of two versions for the same variant. Select a variant, pick two versions, and see their Chains signing metrics mirrored left/right. Includes historical data from legacy test 418.')
++ dashboard.time.withFrom('now-30d')
 + dashboard.time.withTo('now')
 + dashboard.withTimezone('utc')
 + dashboard.withRefresh('5m')
-+ dashboard.withVariables([datasourceVar, deployConfigVar, version1Var, version2Var, testTotalVar])
++ dashboard.withVariables([datasourceVar, variantVar, version1Var, version2Var, testTotalVar])
 + dashboard.withPanels(allPanels)
 + dashboard.withEditable(true)
-+ dashboard.graphTooltip.withSharedCrosshair()
++ dashboard.withTags(['chains', 'comparison', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()

--- a/config/grafonnet-workdir/src/chains-dashboard.jsonnet
+++ b/config/grafonnet-workdir/src/chains-dashboard.jsonnet
@@ -1,60 +1,35 @@
 local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/chains-common.libsonnet';
 
 local dashboard = grafonnet.dashboard;
 local timeSeries = grafonnet.panel.timeSeries;
 
-// ─── Constants ───────────────────────────────────────────────────────────────
-local testId = 418;
-
-// ─── Template variables ─────────────────────────────────────────────────────
-local datasourceVar =
-  grafonnet.dashboard.variable.datasource.new(
-    'datasource',
-    'grafana-postgresql-datasource',
-  )
-  + grafonnet.dashboard.variable.datasource.withRegex('.*grafana-postgresql-datasource.*')
-  + grafonnet.dashboard.variable.custom.generalOptions.withLabel('Datasource')
-  + grafonnet.dashboard.variable.custom.generalOptions.withDescription('PostgreSQL datasource for Chains metrics')
-  + grafonnet.dashboard.variable.custom.generalOptions.withCurrent('grafana-postgresql-datasource');
-
-local deployConfigVar = {
-  type: 'custom',
-  name: 'deploy_config',
-  label: 'Deployment Configuration',
-  description: 'Standard, HA, QBT, or HA+QBT.',
-  query: 'Standard : standard,HA : ha,QBT (non-HA) : qbt,HA + QBT : ha-qbt',
-  multi: false,
-  includeAll: false,
-  current: { text: 'Standard', value: 'standard' },
-  options: [
-    { text: 'Standard', value: 'standard', selected: true },
-    { text: 'HA', value: 'ha', selected: false },
-    { text: 'QBT (non-HA)', value: 'qbt', selected: false },
-    { text: 'HA + QBT', value: 'ha-qbt', selected: false },
-  ],
-};
+local versionExpr = common.versionExpr;
+local testIdPredicate = common.testIdPredicate;
+local datasourceVar = common.datasourceVar;
+local variantVar = common.variantVar;
 
 local versionVar = {
   type: 'query',
   name: 'version',
   label: 'Version',
-  description: 'Filter by Pipelines version.',
+  description: 'Filter to a specific version to track its trend over time.',
   datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
-  query: "SELECT DISTINCT CASE WHEN (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE (label_values->>'__deployment_version') END AS version FROM data WHERE horreum_testid = %g AND label_values ? '__deployment_version' AND (label_values->>'__deployment_version') IS NOT NULL AND label_values ? '__results_PipelineRuns_signing_throughput' ORDER BY version" % testId,
+  query: "SELECT DISTINCT %s AS version FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testIdPredicate],
   multi: false,
   includeAll: false,
   current: { text: 'nightly', value: 'nightly' },
   refresh: 2,
-  sort: 3,
+  sort: 0,
 };
 
 local testTotalVar = {
   type: 'query',
   name: 'test_total',
   label: 'Test Total',
-  description: 'Filter by total PipelineRuns count (500, 1000, 1500).',
+  description: 'Filter by total PipelineRuns count (500, 1000).',
   datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
-  query: "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE horreum_testid = %g AND label_values ? '__parameters_test_total' ORDER BY test_total" % testId,
+  query: "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__parameters_test_total' ORDER BY test_total" % testIdPredicate,
   multi: true,
   includeAll: true,
   current: { text: 'All', value: '$__all' },
@@ -62,31 +37,15 @@ local testTotalVar = {
   sort: 3,
 };
 
-// ─── SQL predicates (injected into every query) ─────────────────────────────
-
 local versionPredicate = |||
-        AND (
-          ('$version' = 'nightly' AND (label_values ? '__deployment_nightly') AND (label_values->>'__deployment_nightly')::BOOLEAN = true)
-          OR ('$version' != 'nightly' AND (label_values->>'__deployment_version') = '$version')
-        )
-|||;
-
-local deployConfigPredicate = |||
-        AND (
-          ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'ha' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
-          OR ('$deploy_config' = 'ha-qbt' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
-        )
-|||;
+        AND %s = '${version}'
+||| % versionExpr;
 
 local testTotalPredicate = |||
         AND (label_values->>'__parameters_test_total')::INTEGER IN ($test_total)
 |||;
 
-// ─── Query builders ─────────────────────────────────────────────────────────
-
-local createQuery(fieldName, metricLabel, additionalFields={}) =
+local createComplexQuery(fieldName, metricLabel, additionalFields={}) =
   local baseFields = { [metricLabel]: fieldName };
   local allFields = baseFields + additionalFields;
   local fieldSelections = std.join(',\n    ', [
@@ -101,7 +60,7 @@ local createQuery(fieldName, metricLabel, additionalFields={}) =
     |||
       SELECT
         EXTRACT(EPOCH FROM day) AS time,
-        '%s @ ' || test_total AS metric,
+        '%s @ t' || test_total AS metric,
         %s AS value
       FROM daily_agg
     ||| % [key, key]
@@ -116,9 +75,8 @@ local createQuery(fieldName, metricLabel, additionalFields={}) =
           (label_values->>'__parameters_test_total')::INTEGER AS test_total,
           %s
         FROM data
-        WHERE horreum_testid = %g
+        WHERE %s
           AND $__timeFilter(start)
-          %s
           %s
           %s
           AND %s
@@ -128,14 +86,12 @@ local createQuery(fieldName, metricLabel, additionalFields={}) =
       %s
 
       ORDER BY time, metric;
-    ||| % [fieldSelections, testId, testTotalPredicate, deployConfigPredicate, versionPredicate, fieldConditions, selectStatements],
+    ||| % [fieldSelections, testIdPredicate, testTotalPredicate, versionPredicate, fieldConditions, selectStatements],
     format: 'time_series',
     refId: 'A',
   };
 
-// ─── Panel builders ─────────────────────────────────────────────────────────
-
-local createPanel(title, fieldName, metricLabel, unit='short', gridX=0, gridY=0, gridW=12, gridH=8, additionalFields={}, description='') =
+local trendPanel(title, fieldName, metricLabel, unit='short', gridX=0, gridY=0, gridW=12, gridH=8, additionalFields={}, description='', axisSoftMax=null) =
   timeSeries.new(title)
   + timeSeries.queryOptions.withDatasource(type='grafana-postgresql-datasource', uid='${datasource}')
   + (if description != '' then timeSeries.panelOptions.withDescription(description) else {})
@@ -144,28 +100,31 @@ local createPanel(title, fieldName, metricLabel, unit='short', gridX=0, gridY=0,
   + timeSeries.gridPos.withW(gridW)
   + timeSeries.gridPos.withH(gridH)
   + timeSeries.fieldConfig.defaults.custom.withDrawStyle('line')
-  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(0)
+  + timeSeries.fieldConfig.defaults.custom.withLineWidth(2)
+  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(8)
+  + timeSeries.fieldConfig.defaults.custom.withGradientMode('opacity')
   + timeSeries.fieldConfig.defaults.custom.withSpanNulls(false)
   + timeSeries.fieldConfig.defaults.custom.withShowPoints('always')
-  + timeSeries.fieldConfig.defaults.custom.withPointSize(7)
+  + timeSeries.fieldConfig.defaults.custom.withPointSize(6)
   + timeSeries.standardOptions.withUnit(unit)
   + timeSeries.standardOptions.withMin(0)
+  + timeSeries.options.withTooltip({ mode: 'multi', sort: 'desc' })
+  + timeSeries.options.withLegend({ displayMode: 'list', placement: 'bottom', calcs: [] })
+  + (if axisSoftMax != null then { fieldConfig+: { defaults+: { custom+: { axisSoftMax: axisSoftMax } } } } else {})
   + timeSeries.queryOptions.withTargets([
-    createQuery(fieldName, metricLabel, additionalFields),
+    createComplexQuery(fieldName, metricLabel, additionalFields),
   ]);
 
-local createRow(title, y) = {
+local row(title, y) = {
   type: 'row',
   title: title,
   gridPos: { h: 1, w: 24, x: 0, y: y },
 };
 
-// ─── Dashboard panels ───────────────────────────────────────────────────────
-
 local allPanels = [
   // ── Signing Results ─────────────────────────────────────────
-  createRow('Signing Results', 0),
-  createPanel(
+  row('Signing Results', 0),
+  trendPanel(
     'PipelineRun Signing Throughput',
     '__results_PipelineRuns_signing_throughput',
     'pr_throughput',
@@ -173,31 +132,31 @@ local allPanels = [
     0, 1, 12, 8,
     description='PipelineRun signing throughput (signed runs per second). Higher is better. Computed as signed_count / signing_window_duration.'
   ),
-  createPanel(
+  trendPanel(
     'TaskRun Signing Throughput',
     '__results_TaskRuns_signing_throughput',
     'tr_throughput',
     'short',
     12, 1, 12, 8,
-    description='TaskRun signing throughput (signed runs per second). Higher is better. Computed as signed_count / signing_window_duration.'
+    description='TaskRun signing throughput (signed runs per second). Higher is better.'
   ),
-  createPanel(
+  trendPanel(
     'PipelineRun Signing Duration',
     '__results_PipelineRuns_signing_duration',
     'pr_sign_duration',
     's',
     0, 9, 12, 8,
-    description='Total wall-clock time of the PipelineRun signing window (last signed_at - first signed_at). Lower is better — indicates how quickly Chains processes the entire batch.'
+    description='Total wall-clock time of the PipelineRun signing window (last signed_at - first signed_at). Lower is better.'
   ),
-  createPanel(
+  trendPanel(
     'TaskRun Signing Duration',
     '__results_TaskRuns_signing_duration',
     'tr_sign_duration',
     's',
     12, 9, 12, 8,
-    description='Total wall-clock time of the TaskRun signing window (last signed_at - first signed_at). Lower is better.'
+    description='Total wall-clock time of the TaskRun signing window. Lower is better.'
   ),
-  createPanel(
+  trendPanel(
     'PipelineRun Signed Count',
     '__results_PipelineRuns_signing_count_signed_true',
     'pr_signed',
@@ -209,7 +168,7 @@ local allPanels = [
     },
     description='PipelineRun signing outcome breakdown:\n- **pr_signed**: successfully signed\n- **pr_unsigned**: never signed (still pending)\n- **pr_sign_failed**: signing attempted but failed\n\nAll runs should be signed; any unsigned or failed entries indicate a problem.'
   ),
-  createPanel(
+  trendPanel(
     'TaskRun Signed Count',
     '__results_TaskRuns_signing_count_signed_true',
     'tr_signed',
@@ -219,12 +178,12 @@ local allPanels = [
       tr_unsigned: '__results_TaskRuns_signing_count_unsigned',
       tr_sign_failed: '__results_TaskRuns_signing_count_signed_false',
     },
-    description='TaskRun signing outcome breakdown:\n- **tr_signed**: successfully signed\n- **tr_unsigned**: never signed (still pending)\n- **tr_sign_failed**: signing attempted but failed'
+    description='TaskRun signing outcome breakdown:\n- **tr_signed**: successfully signed\n- **tr_unsigned**: never signed\n- **tr_sign_failed**: signing failed'
   ),
 
   // ── PipelineRun / TaskRun Counts ──────────────────────────────
-  createRow('PipelineRun & TaskRun Counts', 25),
-  createPanel(
+  row('PipelineRun & TaskRun Counts', 25),
+  trendPanel(
     'PipelineRun Succeeded',
     '__results_PipelineRuns_count_succeeded',
     'pr_succeeded',
@@ -232,15 +191,16 @@ local allPanels = [
     0, 26, 12, 8,
     description='Total PipelineRuns that completed successfully, averaged per day per test_total.'
   ),
-  createPanel(
+  trendPanel(
     'PipelineRun Failed',
     '__results_PipelineRuns_count_failed',
     'pr_failed',
     'short',
     12, 26, 12, 8,
-    description='Total PipelineRuns that failed. Should be 0.'
+    description='Total PipelineRuns that failed. Should be 0.',
+    axisSoftMax=5,
   ),
-  createPanel(
+  trendPanel(
     'TaskRun Succeeded',
     '__results_TaskRuns_count_succeeded',
     'tr_succeeded',
@@ -248,114 +208,116 @@ local allPanels = [
     0, 34, 12, 8,
     description='Total TaskRuns that completed successfully.'
   ),
-  createPanel(
+  trendPanel(
     'TaskRun Failed',
     '__results_TaskRuns_count_failed',
     'tr_failed',
     'short',
     12, 34, 12, 8,
-    description='Total TaskRuns that failed. Should be 0.'
+    description='Total TaskRuns that failed. Should be 0.',
+    axisSoftMax=5,
   ),
 
   // ── Chains Controller Metrics ─────────────────────────────────
-  createRow('Chains Controller Metrics', 42),
-  createPanel(
+  row('Chains Controller Metrics', 42),
+  trendPanel(
     'Chains Controller CPU Usage',
     '__measurements_tektonChainsController_cpu_mean',
     'cpu_mean',
     'short',
     0, 43, 12, 8,
     { cpu_max: '__measurements_tektonChainsController_cpu_max' },
-    description='Tekton Chains controller CPU usage in CPU cores (e.g. 0.5 = 500 millicores).\n- **cpu_mean**: average over the test window\n- **cpu_max**: peak usage\n\nHigh CPU indicates signing is compute-bound (e.g. cryptographic operations).'
+    description='Tekton Chains controller CPU usage in CPU cores.\n- **cpu_mean**: average over the test window\n- **cpu_max**: peak usage'
   ),
-  createPanel(
+  trendPanel(
     'Chains Controller Memory Usage',
     '__measurements_tektonChainsController_memory_mean',
     'mem_mean',
     'bytes',
     12, 43, 12, 8,
     { mem_max: '__measurements_tektonChainsController_memory_max' },
-    description='Tekton Chains controller memory (RSS) usage.\n- **mem_mean**: average over the test window\n- **mem_max**: peak usage\n\nGrowing memory may indicate leaks or large attestation payloads.'
+    description='Tekton Chains controller memory (RSS) usage.\n- **mem_mean**: average\n- **mem_max**: peak'
   ),
-  createPanel(
+  trendPanel(
     'Chains Controller Workqueue Depth',
     '__measurements_tektonChainsControllerWorkqueueDepth_mean',
     'wq_mean',
     'short',
     0, 51, 12, 8,
     { wq_max: '__measurements_tektonChainsControllerWorkqueueDepth_max' },
-    description='Chains controller workqueue depth.\n- **wq_mean**: average queue depth during the test\n- **wq_max**: peak queue depth\n\nA growing workqueue means the controller cannot sign runs fast enough. Sustained high values indicate a bottleneck.'
+    description='Chains controller workqueue depth.\n- **wq_mean**: average queue depth\n- **wq_max**: peak queue depth\n\nSustained high values indicate a signing bottleneck.'
   ),
-  createPanel(
+  trendPanel(
     'Chains Controller Restarts',
     '__measurements_tektonChainsController_restarts_range',
     'chains_restarts',
     'short',
     12, 51, 12, 8,
-    description='Number of Chains controller Pod restarts during the test. Should be 0. Restarts during signing cause missed or delayed signatures.'
+    description='Chains controller Pod restarts during the test. Should be 0.',
+    axisSoftMax=5,
   ),
 
   // ── Cluster & API Server Metrics ──────────────────────────────
-  createRow('Cluster & API Server Metrics', 59),
-  createPanel(
+  row('Cluster & API Server Metrics', 59),
+  trendPanel(
     'Cluster CPU Usage',
     '__measurements_clusterCpuUsageSecondsTotalRate_mean',
     'cluster_cpu',
     'short',
     0, 60, 12, 8,
-    description='Mean total CPU usage rate across all cluster nodes during the test, in CPU cores.'
+    description='Mean total CPU usage rate across all cluster nodes, in CPU cores.'
   ),
-  createPanel(
+  trendPanel(
     'Cluster Memory Usage',
     '__measurements_clusterMemoryUsageRssTotal_mean',
     'cluster_mem',
     'bytes',
     12, 60, 12, 8,
-    description='Mean total RSS memory usage across all cluster nodes during the test.'
+    description='Mean total RSS memory usage across all cluster nodes.'
   ),
-  createPanel(
-    'API Server CPU Usage (Mean)',
+  trendPanel(
+    'API Server CPU (OpenShift / Kube)',
     '__measurements_apiserver_cpu_mean',
-    'apiserver_cpu',
+    'ocp_apiserver_cpu',
     'short',
     0, 68, 12, 8,
     { kube_apiserver_cpu: '__measurements_kubeApiserver_cpu_mean' },
-    description='Mean CPU usage of OpenShift and Kubernetes API servers.\n- **apiserver_cpu**: openshift-apiserver\n- **kube_apiserver_cpu**: kube-apiserver'
+    description='Mean CPU usage of the OpenShift and Kubernetes API servers.'
   ),
-  createPanel(
-    'API Server Memory Usage (Mean)',
+  trendPanel(
+    'API Server Memory (OpenShift / Kube)',
     '__measurements_apiserver_memory_mean',
-    'apiserver_mem',
+    'ocp_apiserver_mem',
     'bytes',
     12, 68, 12, 8,
     { kube_apiserver_mem: '__measurements_kubeApiserver_memory_mean' },
-    description='Mean memory usage of OpenShift and Kubernetes API servers.'
+    description='Mean memory usage of the OpenShift and Kubernetes API servers.'
   ),
 
   // ── etcd Metrics ──────────────────────────────────────────────
-  createRow('etcd Metrics', 76),
-  createPanel(
-    'etcd MVCC DB Size (Mean)',
+  row('etcd Metrics', 76),
+  trendPanel(
+    'etcd DB Size (total / in-use)',
     '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean',
     'db_total',
     'bytes',
     0, 77, 12, 8,
     { db_in_use: '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean' },
-    description='Mean etcd MVCC database size.\n- **db_total**: total allocated size on disk\n- **db_in_use**: logical size of live data\n\nChains stores signing metadata in annotations, which increases etcd load.'
+    description='Mean etcd MVCC database size.\n- **db_total**: total allocated size on disk\n- **db_in_use**: live data size\n\nChains stores signing metadata in annotations, which increases etcd load.'
   ),
-  createPanel(
-    'etcd Request Duration',
+  trendPanel(
+    'etcd Request Duration (mean / max)',
     '__measurements_etcdRequestDurationSecondsAverage_mean',
     'req_duration_mean',
     's',
     12, 77, 12, 8,
     { req_duration_max: '__measurements_etcdRequestDurationSecondsAverage_max' },
-    description='Mean and peak etcd request duration.\n- **req_duration_mean**: average latency\n- **req_duration_max**: worst-case latency\n\nHigh values indicate etcd pressure from Chains annotation writes.'
+    description='Mean and peak etcd request duration.\n- **req_duration_mean**: average latency\n- **req_duration_max**: worst-case latency'
   ),
 
   // ── Restarts ──────────────────────────────────────────────────
-  createRow('Component Restarts', 85),
-  createPanel(
+  row('Component Restarts', 85),
+  trendPanel(
     'Infrastructure Restarts',
     '__measurements_etcd_restarts_range',
     'etcd',
@@ -365,9 +327,10 @@ local allPanels = [
       apiserver: '__measurements_apiserver_restarts_range',
       kube_apiserver: '__measurements_kubeApiserver_restarts_range',
     },
-    description='Restart counts for infrastructure components. All should be 0.'
+    description='Restart counts for infrastructure components. All should be 0.',
+    axisSoftMax=5,
   ),
-  createPanel(
+  trendPanel(
     'Tekton Component Restarts',
     '__measurements_tektonPipelinesController_restarts_range',
     'pipelines_ctrl',
@@ -377,28 +340,29 @@ local allPanels = [
       pipelines_webhook: '__measurements_tektonPipelinesWebhook_restarts_range',
       proxy_webhook: '__measurements_tektonOperatorProxyWebhook_restarts_range',
     },
-    description='Restart counts for Tekton Pipelines components. All should be 0.\n\nNote: Chains controller restarts are shown separately in the Chains Controller section above.'
+    description='Restart counts for Tekton Pipelines components. All should be 0.',
+    axisSoftMax=5,
   ),
-  createPanel(
+  trendPanel(
     'Scheduler Pending Pods',
     '__measurements_schedulerPendingPodsCount_range',
     'pending_pods',
     'short',
     0, 94, 12, 8,
-    description='Range of pending pods in the kube-scheduler queue. High values indicate scheduling pressure.'
+    description='Range of pending pods in the kube-scheduler queue.',
+    axisSoftMax=5,
   ),
 ];
 
-// ─── Dashboard ──────────────────────────────────────────────────────────────
-
 dashboard.new('Chains Signing Performance Dashboard')
 + dashboard.withUid('Chains_Signing_Performance')
-+ dashboard.withDescription('OpenShift Pipelines Chains signing performance. Tracks signing throughput, duration, Chains controller resources, and cluster health across different test_total values (500, 1000, 1500).')
-+ dashboard.time.withFrom('now-14d')
++ dashboard.withDescription('OpenShift Pipelines Chains signing performance trends per variant and version. Includes historical data from legacy test 418 and new per-variant tests (427-430). Select a variant, version, and test total to track regressions over time.')
++ dashboard.time.withFrom('now-30d')
 + dashboard.time.withTo('now')
 + dashboard.withTimezone('utc')
 + dashboard.withRefresh('5m')
-+ dashboard.withVariables([datasourceVar, deployConfigVar, versionVar, testTotalVar])
++ dashboard.withVariables([datasourceVar, variantVar, versionVar, testTotalVar])
 + dashboard.withPanels(allPanels)
 + dashboard.withEditable(true)
-+ dashboard.graphTooltip.withSharedCrosshair()
++ dashboard.withTags(['chains', 'trend', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()

--- a/config/grafonnet-workdir/src/chains-version-comparison-v2.jsonnet
+++ b/config/grafonnet-workdir/src/chains-version-comparison-v2.jsonnet
@@ -1,0 +1,151 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/chains-common.libsonnet';
+local versionBarLib = import 'lib/version-bar-common.libsonnet';
+
+local dashboard = grafonnet.dashboard;
+
+local versionExpr = common.versionExpr;
+local testIdPredicate = common.testIdPredicate;
+local datasourceVar = common.datasourceVar;
+local variantVar = common.variantVar;
+
+local versionVar = {
+  type: 'query',
+  name: 'version',
+  label: 'Version',
+  description: 'Select versions to compare. Use All to include every version.',
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: "SELECT DISTINCT %s AS version FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testIdPredicate],
+  multi: true,
+  includeAll: true,
+  current: { text: 'All', value: '$__all' },
+  refresh: 2,
+  sort: 0,
+};
+
+local testTotalVar = {
+  type: 'query',
+  name: 'test_total',
+  label: 'Test Total',
+  description: 'Select a single test total to compare versions at.',
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: "SELECT DISTINCT (label_values->>'__parameters_test_total')::INTEGER AS test_total FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__parameters_test_total' ORDER BY test_total" % testIdPredicate,
+  multi: false,
+  includeAll: false,
+  current: { text: '500', value: '500' },
+  refresh: 2,
+  sort: 3,
+};
+
+local createQuery(fieldName, agg='AVG') =
+  {
+    rawSql: |||
+      WITH daily AS (
+        SELECT
+          TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,
+          DATE_TRUNC('day', start) AS day_date,
+          %s AS version,
+          (label_values->>'%s')::DOUBLE PRECISION AS val
+        FROM data
+        WHERE %s
+          AND $__timeFilter(start)
+          AND %s IN ($version)
+          AND (label_values->>'__parameters_test_total')::INTEGER = ${test_total}::INTEGER
+          AND label_values ? '%s'
+      )
+      SELECT day, version, %s(val) AS value
+      FROM daily
+      GROUP BY day, version
+      ORDER BY MIN(day_date),
+        CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,
+        version ASC
+    ||| % [versionExpr, fieldName, testIdPredicate, versionExpr, fieldName, agg],
+    format: 'table',
+    refId: 'A',
+  };
+
+local row = versionBarLib.row;
+
+local versionBar(title, fieldName, unit, x, y, w, h, description='', agg='AVG', axisSoftMax=null) =
+  versionBarLib.versionBar(createQuery, title, fieldName, unit, x, y, w, h, description, agg, axisSoftMax);
+
+local pw = 24;
+local ph = 8;
+
+local allPanels = [
+  // ── Signing Results ─────────────────────────────────────────
+  row('Signing Results', 0),
+  versionBar('PipelineRun Signing Throughput', '__results_PipelineRuns_signing_throughput', 'short', 0, 1, pw, ph,
+    description='PipelineRun signing throughput per version per day (signed/sec). Higher is better.'),
+  versionBar('TaskRun Signing Throughput', '__results_TaskRuns_signing_throughput', 'short', 0, 9, pw, ph,
+    description='TaskRun signing throughput per version per day (signed/sec). Higher is better.'),
+  versionBar('PipelineRun Signing Duration', '__results_PipelineRuns_signing_duration', 's', 0, 17, pw, ph,
+    description='Total PipelineRun signing window duration per version per day. Lower is better.'),
+  versionBar('TaskRun Signing Duration', '__results_TaskRuns_signing_duration', 's', 0, 25, pw, ph,
+    description='Total TaskRun signing window duration per version per day. Lower is better.'),
+  versionBar('PipelineRun Signed Count', '__results_PipelineRuns_signing_count_signed_true', 'short', 0, 33, pw, ph,
+    description='PipelineRuns signed successfully per version per day.', agg='SUM'),
+  versionBar('PipelineRun Unsigned', '__results_PipelineRuns_signing_count_unsigned', 'short', 0, 41, pw, ph,
+    description='PipelineRuns that remained unsigned per version per day. Should be 0.', agg='SUM', axisSoftMax=5),
+  versionBar('TaskRun Signed Count', '__results_TaskRuns_signing_count_signed_true', 'short', 0, 49, pw, ph,
+    description='TaskRuns signed successfully per version per day.', agg='SUM'),
+  versionBar('TaskRun Unsigned', '__results_TaskRuns_signing_count_unsigned', 'short', 0, 57, pw, ph,
+    description='TaskRuns that remained unsigned per version per day. Should be 0.', agg='SUM', axisSoftMax=5),
+
+  // ── PipelineRun / TaskRun Counts ──────────────────────────────
+  row('PipelineRun & TaskRun Counts', 65),
+  versionBar('PipelineRun Succeeded', '__results_PipelineRuns_count_succeeded', 'short', 0, 66, pw, ph,
+    description='Successful PipelineRuns per version per day.', agg='SUM'),
+  versionBar('PipelineRun Failed', '__results_PipelineRuns_count_failed', 'short', 0, 74, pw, ph,
+    description='Failed PipelineRuns per version per day. Should be 0.', agg='SUM', axisSoftMax=5),
+  versionBar('TaskRun Succeeded', '__results_TaskRuns_count_succeeded', 'short', 0, 82, pw, ph,
+    description='Successful TaskRuns per version per day.', agg='SUM'),
+  versionBar('TaskRun Failed', '__results_TaskRuns_count_failed', 'short', 0, 90, pw, ph,
+    description='Failed TaskRuns per version per day. Should be 0.', agg='SUM', axisSoftMax=5),
+
+  // ── Chains Controller Metrics ─────────────────────────────────
+  row('Chains Controller Metrics', 98),
+  versionBar('Chains Controller CPU (mean)', '__measurements_tektonChainsController_cpu_mean', 'short', 0, 99, pw, ph,
+    description='Tekton Chains controller mean CPU per version per day.'),
+  versionBar('Chains Controller Memory (mean)', '__measurements_tektonChainsController_memory_mean', 'bytes', 0, 107, pw, ph,
+    description='Tekton Chains controller mean memory (RSS) per version per day.'),
+  versionBar('Chains Controller Workqueue Depth', '__measurements_tektonChainsControllerWorkqueueDepth_mean', 'short', 0, 115, pw, ph,
+    description='Chains controller mean workqueue depth per version per day. High values indicate a signing bottleneck.'),
+  versionBar('Chains Controller Restarts', '__measurements_tektonChainsController_restarts_range', 'short', 0, 123, pw, ph,
+    description='Chains controller restarts per version per day. Should be 0.', agg='SUM', axisSoftMax=5),
+
+  // ── Cluster & API Server Metrics ──────────────────────────────
+  row('Cluster & API Server', 131),
+  versionBar('Cluster CPU', '__measurements_clusterCpuUsageSecondsTotalRate_mean', 'short', 0, 132, pw, ph,
+    description='Mean total cluster CPU usage per version per day.'),
+  versionBar('Cluster Memory', '__measurements_clusterMemoryUsageRssTotal_mean', 'bytes', 0, 140, pw, ph,
+    description='Mean total cluster RSS memory per version per day.'),
+  versionBar('API Server CPU', '__measurements_apiserver_cpu_mean', 'short', 0, 148, pw, ph,
+    description='OpenShift API server mean CPU per version per day.'),
+  versionBar('API Server Memory', '__measurements_apiserver_memory_mean', 'bytes', 0, 156, pw, ph,
+    description='OpenShift API server mean memory per version per day.'),
+
+  // ── etcd ──────────────────────────────────────────────────────
+  row('etcd', 164),
+  versionBar('etcd DB Size', '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean', 'bytes', 0, 165, pw, ph,
+    description='Mean etcd MVCC database total size per version per day.'),
+  versionBar('etcd Request Duration', '__measurements_etcdRequestDurationSecondsAverage_mean', 's', 0, 173, pw, ph,
+    description='Mean etcd request latency per version per day.'),
+  versionBar('etcd Restarts', '__measurements_etcd_restarts_range', 'short', 0, 181, pw, ph,
+    description='etcd Pod restarts per version per day. Should be 0.', agg='SUM', axisSoftMax=5),
+  versionBar('Scheduler Pending Pods', '__measurements_schedulerPendingPodsCount_range', 'short', 0, 189, pw, ph,
+    description='Pending pods in kube-scheduler queue per version per day.', agg='SUM', axisSoftMax=5),
+];
+
+dashboard.new('Chains Version Comparison (v2)')
++ dashboard.withUid('Chains_Version_Comparison_v2')
++ dashboard.withDescription('Daily side-by-side version comparison of Chains signing performance. Includes historical data from legacy test 418 and new per-variant tests (427-430).')
++ dashboard.time.withFrom('now-14d')
++ dashboard.time.withTo('now')
++ dashboard.withTimezone('utc')
++ dashboard.withRefresh('5m')
++ dashboard.withVariables([datasourceVar, variantVar, versionVar, testTotalVar])
++ dashboard.withPanels(allPanels)
++ dashboard.withEditable(true)
++ dashboard.withTags(['chains', 'version-comparison', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()

--- a/config/grafonnet-workdir/src/lib/chains-common.libsonnet
+++ b/config/grafonnet-workdir/src/lib/chains-common.libsonnet
@@ -1,0 +1,58 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+
+{
+  versionExpr: "CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END",
+
+  // Variant → Test ID mapping:
+  //   427 = Standard, 428 = HA, 429 = QBT, 430 = HA+QBT
+  //   418 = legacy (filtered by HA/QBT config)
+  testIdPredicate: |||
+    (
+      horreum_testid = ${variant}::INTEGER
+      OR (
+        horreum_testid = 418
+        AND (
+          (${variant}::INTEGER = 427
+            AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)
+            AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
+          OR (${variant}::INTEGER = 428
+            AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true
+            AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
+          OR (${variant}::INTEGER = 429
+            AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)
+            AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
+          OR (${variant}::INTEGER = 430
+            AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true
+            AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
+        )
+      )
+    )
+  |||,
+
+  datasourceVar:
+    grafonnet.dashboard.variable.datasource.new(
+      'datasource',
+      'grafana-postgresql-datasource',
+    )
+    + grafonnet.dashboard.variable.datasource.withRegex('.*grafana-postgresql-datasource.*')
+    + grafonnet.dashboard.variable.custom.generalOptions.withLabel('Datasource')
+    + grafonnet.dashboard.variable.custom.generalOptions.withDescription('PostgreSQL datasource for Chains metrics')
+    + grafonnet.dashboard.variable.custom.generalOptions.withCurrent('grafana-postgresql-datasource'),
+
+  variantVar: {
+    type: 'custom',
+    name: 'variant',
+    label: 'Variant',
+    description: 'Chains deployment variant (each maps to a separate Horreum test ID).',
+    query: 'Standard : 427,HA : 428,QBT (non-HA) : 429,HA + QBT : 430',
+    multi: false,
+    includeAll: false,
+    current: { text: 'Standard', value: '427' },
+    options: [
+      { text: 'Standard', value: '427', selected: true },
+      { text: 'HA', value: '428', selected: false },
+      { text: 'QBT (non-HA)', value: '429', selected: false },
+      { text: 'HA + QBT', value: '430', selected: false },
+    ],
+  },
+}

--- a/config/grafonnet-workdir/src/lib/pipelines-common.libsonnet
+++ b/config/grafonnet-workdir/src/lib/pipelines-common.libsonnet
@@ -1,0 +1,65 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+
+{
+  versionExpr: "CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END",
+
+  // Variant → Test ID mapping:
+  //   423 = Standard, 419 = HA-Deployments, 421 = HA-StatefulSets
+  //   422 = QBT, 420 = HA+QBT, 391 = legacy (filtered by HA/QBT config)
+  testIdPredicate: |||
+    (
+      horreum_testid = ${variant}::INTEGER
+      OR (
+        horreum_testid = 391
+        AND (
+          (${variant}::INTEGER = 423
+            AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)
+            AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
+          OR (${variant}::INTEGER = 419
+            AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true
+            AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'
+            AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
+          OR (${variant}::INTEGER = 421
+            AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true
+            AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets'
+            AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
+          OR (${variant}::INTEGER = 422
+            AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false)
+            AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
+          OR (${variant}::INTEGER = 420
+            AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true
+            AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments'
+            AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
+        )
+      )
+    )
+  |||,
+
+  datasourceVar:
+    grafonnet.dashboard.variable.datasource.new(
+      'datasource',
+      'grafana-postgresql-datasource',
+    )
+    + grafonnet.dashboard.variable.datasource.withRegex('.*grafana-postgresql-datasource.*')
+    + grafonnet.dashboard.variable.custom.generalOptions.withLabel('Datasource')
+    + grafonnet.dashboard.variable.custom.generalOptions.withDescription('PostgreSQL datasource for pipeline metrics')
+    + grafonnet.dashboard.variable.custom.generalOptions.withCurrent('grafana-postgresql-datasource'),
+
+  variantVar: {
+    type: 'custom',
+    name: 'variant',
+    label: 'Variant',
+    description: 'Pipeline deployment variant (each maps to a separate Horreum test ID).',
+    query: 'Standard : 423,HA - Deployments : 419,HA - StatefulSets : 421,QBT (non-HA) : 422,HA + QBT : 420',
+    multi: false,
+    includeAll: false,
+    current: { text: 'Standard', value: '423' },
+    options: [
+      { text: 'Standard', value: '423', selected: true },
+      { text: 'HA - Deployments', value: '419', selected: false },
+      { text: 'HA - StatefulSets', value: '421', selected: false },
+      { text: 'QBT (non-HA)', value: '422', selected: false },
+      { text: 'HA + QBT', value: '420', selected: false },
+    ],
+  },
+}

--- a/config/grafonnet-workdir/src/lib/results-common.libsonnet
+++ b/config/grafonnet-workdir/src/lib/results-common.libsonnet
@@ -1,0 +1,17 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+
+{
+  testId: 425,
+
+  versionExpr: "CASE WHEN label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = true THEN 'nightly' ELSE COALESCE(label_values->>'__deployment_version', 'unknown') END",
+
+  datasourceVar:
+    grafonnet.dashboard.variable.datasource.new(
+      'datasource',
+      'grafana-postgresql-datasource',
+    )
+    + grafonnet.dashboard.variable.datasource.withRegex('.*grafana-postgresql-datasource.*')
+    + grafonnet.dashboard.variable.custom.generalOptions.withLabel('Datasource')
+    + grafonnet.dashboard.variable.custom.generalOptions.withDescription('PostgreSQL datasource for Results metrics')
+    + grafonnet.dashboard.variable.custom.generalOptions.withCurrent('grafana-postgresql-datasource'),
+}

--- a/config/grafonnet-workdir/src/lib/version-bar-common.libsonnet
+++ b/config/grafonnet-workdir/src/lib/version-bar-common.libsonnet
@@ -1,0 +1,53 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local barChart = grafonnet.panel.barChart;
+
+// Column ordering: nightly first, then 1.0-1.50. Unused entries are ignored.
+local versionOrder = ['nightly'] + ['1.%d' % i for i in std.range(0, 50)];
+
+local matrixTransform = [
+  {
+    id: 'groupingToMatrix',
+    options: {
+      columnField: 'version',
+      rowField: 'day',
+      valueField: 'value',
+    },
+  },
+  {
+    id: 'organize',
+    options: {
+      indexByName: { ['day\\version']: 0 } + {
+        [versionOrder[i]]: i + 1
+        for i in std.range(0, std.length(versionOrder) - 1)
+      },
+    },
+  },
+];
+
+{
+  row(title, y): {
+    type: 'row',
+    title: title,
+    gridPos: { h: 1, w: 24, x: 0, y: y },
+  },
+
+  versionBar(buildQuery, title, fieldName, unit, x, y, w, h, description='', agg='AVG', axisSoftMax=null):
+    barChart.new(title)
+    + barChart.queryOptions.withDatasource(type='grafana-postgresql-datasource', uid='${datasource}')
+    + (if description != '' then barChart.panelOptions.withDescription(description) else {})
+    + barChart.gridPos.withX(x)
+    + barChart.gridPos.withY(y)
+    + barChart.gridPos.withW(w)
+    + barChart.gridPos.withH(h)
+    + barChart.standardOptions.withUnit(unit)
+    + barChart.standardOptions.withMin(0)
+    + (if agg == 'SUM' then barChart.standardOptions.withDecimals(0) else {})
+    + barChart.options.withTooltip({ mode: 'multi', sort: 'none' })
+    + barChart.options.withLegend({ displayMode: 'list', placement: 'bottom', calcs: [] })
+    + barChart.options.withBarWidth(0.85)
+    + barChart.options.withGroupWidth(0.55)
+    + barChart.options.withShowValue('never')
+    + (if axisSoftMax != null then { fieldConfig+: { defaults+: { custom+: { axisSoftMax: axisSoftMax } } } } else {})
+    + barChart.queryOptions.withTargets([buildQuery(fieldName, agg)])
+    + barChart.queryOptions.withTransformations(matrixTransform),
+}

--- a/config/grafonnet-workdir/src/pipelines-comparison-dashboard.jsonnet
+++ b/config/grafonnet-workdir/src/pipelines-comparison-dashboard.jsonnet
@@ -1,57 +1,32 @@
 local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/pipelines-common.libsonnet';
 
 local dashboard = grafonnet.dashboard;
 local timeSeries = grafonnet.panel.timeSeries;
 
-// ─── Constants ───────────────────────────────────────────────────────────────
-local testId = 391;
-local versionQuery = "SELECT DISTINCT (label_values->>'__deployment_version') AS __text FROM data WHERE horreum_testid = %g AND label_values ? '__deployment_version' AND (label_values->>'__deployment_version') IS NOT NULL AND (label_values ? '__deployment_nightly' AND (label_values->>'__deployment_nightly')::BOOLEAN = false) ORDER BY __text" % testId;
+local versionExpr = common.versionExpr;
+local testIdPredicate = common.testIdPredicate;
+local datasourceVar = common.datasourceVar;
+local variantVar = common.variantVar;
 
-// ─── Template variables ─────────────────────────────────────────────────────
-local datasourceVar =
-  grafonnet.dashboard.variable.datasource.new(
-    'datasource',
-    'grafana-postgresql-datasource',
-  )
-  + grafonnet.dashboard.variable.datasource.withRegex('.*grafana-postgresql-datasource.*')
-  + grafonnet.dashboard.variable.custom.generalOptions.withLabel('Datasource')
-  + grafonnet.dashboard.variable.custom.generalOptions.withDescription('PostgreSQL datasource for pipeline metrics')
-  + grafonnet.dashboard.variable.custom.generalOptions.withCurrent('grafana-postgresql-datasource');
+local versionQuery = "SELECT DISTINCT %s AS version FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testIdPredicate];
 
 local createVersionVar(name, label, defaultVersion) = {
   type: 'query',
   name: name,
   label: label,
-  description: '%s for comparison' % label,
+  description: '%s for comparison.' % label,
   datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
   query: versionQuery,
   multi: false,
   includeAll: false,
   current: { text: defaultVersion, value: defaultVersion },
   refresh: 2,
-  sort: 3,
+  sort: 0,
 };
 
-local version1Var = createVersionVar('version1', 'Version 1', '1.19');
-local version2Var = createVersionVar('version2', 'Version 2', '1.20');
-
-local deployConfigVar = {
-  type: 'custom',
-  name: 'deploy_config',
-  label: 'Deployment Configuration',
-  description: 'Filter by deployment configuration: Standard, HA, QBT, or HA+QBT.',
-  query: 'Standard : standard,HA - Deployments : ha-deployments,HA - StatefulSets : ha-statefulsets,QBT (non-HA) : qbt,HA + QBT - Deployments : ha-qbt-deployments',
-  multi: false,
-  includeAll: false,
-  current: { text: 'Standard', value: 'standard' },
-  options: [
-    { text: 'Standard', value: 'standard', selected: true },
-    { text: 'HA - Deployments', value: 'ha-deployments', selected: false },
-    { text: 'HA - StatefulSets', value: 'ha-statefulsets', selected: false },
-    { text: 'QBT (non-HA)', value: 'qbt', selected: false },
-    { text: 'HA + QBT - Deployments', value: 'ha-qbt-deployments', selected: false },
-  ],
-};
+local version1Var = createVersionVar('version1', 'Version 1', 'nightly');
+local version2Var = createVersionVar('version2', 'Version 2', '1.23');
 
 local concurrencyVar = {
   type: 'query',
@@ -59,7 +34,7 @@ local concurrencyVar = {
   label: 'Concurrency',
   description: 'Filter by concurrency level. Select one or more, or All.',
   datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
-  query: "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE horreum_testid = %g AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency" % testId,
+  query: "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency" % testIdPredicate,
   multi: true,
   includeAll: true,
   current: { text: 'All', value: '$__all' },
@@ -67,30 +42,13 @@ local concurrencyVar = {
   sort: 3,
 };
 
-// ─── SQL predicates ─────────────────────────────────────────────────────────
-
 local versionPredicate(varName) = |||
-        AND label_values ? '__deployment_version'
-        AND (label_values->>'__deployment_version') = '${%s}'
-        AND label_values ? '__deployment_nightly'
-        AND (label_values->>'__deployment_nightly')::BOOLEAN = false
-||| % varName;
-
-local deployConfigPredicate = |||
-        AND (
-          ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
-          OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
-        )
-|||;
+        AND %s = '${%s}'
+||| % [versionExpr, varName];
 
 local concurrencyPredicate = |||
         AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)
 |||;
-
-// ─── Query builders ─────────────────────────────────────────────────────────
 
 local createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields={}) =
   local baseFields = { [metricLabel]: fieldName };
@@ -107,7 +65,7 @@ local createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields
     |||
       SELECT
         EXTRACT(EPOCH FROM day) AS time,
-        '%s @ ' || concurrency AS metric,
+        '%s @ c' || concurrency AS metric,
         %s AS value
       FROM daily_agg
     ||| % [key, key]
@@ -122,9 +80,8 @@ local createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields
           (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,
           %s
         FROM data
-        WHERE horreum_testid = %g
+        WHERE %s
           AND $__timeFilter(start)
-          %s
           %s
           %s
           AND %s
@@ -134,15 +91,13 @@ local createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields
       %s
 
       ORDER BY time, metric;
-    ||| % [fieldSelections, testId, concurrencyPredicate, deployConfigPredicate, versionPredicate(versionVar), fieldConditions, selectStatements],
+    ||| % [fieldSelections, testIdPredicate, concurrencyPredicate, versionPredicate(versionVar), fieldConditions, selectStatements],
     format: 'time_series',
     refId: 'A',
   };
 
-// ─── Panel builders ─────────────────────────────────────────────────────────
-
-local createComparisonPanel(title, fieldName, metricLabel, unit, gridX, gridY, gridW=12, gridH=8, versionVar='version1', additionalFields={}, description='') =
-  timeSeries.new('%s - v${%s}' % [title, versionVar])
+local comparisonPanel(title, fieldName, metricLabel, unit, gridX, gridY, gridW=12, gridH=8, versionVar='version1', additionalFields={}, description='', axisSoftMax=null) =
+  timeSeries.new('%s — ${%s}' % [title, versionVar])
   + timeSeries.queryOptions.withDatasource(type='grafana-postgresql-datasource', uid='${datasource}')
   + (if description != '' then timeSeries.panelOptions.withDescription(description) else {})
   + timeSeries.gridPos.withX(gridX)
@@ -150,158 +105,162 @@ local createComparisonPanel(title, fieldName, metricLabel, unit, gridX, gridY, g
   + timeSeries.gridPos.withW(gridW)
   + timeSeries.gridPos.withH(gridH)
   + timeSeries.fieldConfig.defaults.custom.withDrawStyle('line')
-  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(0)
+  + timeSeries.fieldConfig.defaults.custom.withLineWidth(2)
+  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(8)
+  + timeSeries.fieldConfig.defaults.custom.withGradientMode('opacity')
   + timeSeries.fieldConfig.defaults.custom.withSpanNulls(false)
   + timeSeries.fieldConfig.defaults.custom.withShowPoints('always')
-  + timeSeries.fieldConfig.defaults.custom.withPointSize(7)
+  + timeSeries.fieldConfig.defaults.custom.withPointSize(6)
   + timeSeries.standardOptions.withUnit(unit)
   + timeSeries.standardOptions.withMin(0)
+  + timeSeries.options.withTooltip({ mode: 'multi', sort: 'desc' })
+  + timeSeries.options.withLegend({ displayMode: 'list', placement: 'bottom', calcs: [] })
+  + (if axisSoftMax != null then { fieldConfig+: { defaults+: { custom+: { axisSoftMax: axisSoftMax } } } } else {})
   + timeSeries.queryOptions.withTargets([
     createComparisonQuery(fieldName, metricLabel, versionVar, additionalFields),
   ]);
 
-local createPanelPair(title, fieldName, metricLabel, unit, y, additionalFields={}, description='') = [
-  createComparisonPanel(title, fieldName, metricLabel, unit, 0, y, versionVar='version1', additionalFields=additionalFields, description=description),
-  createComparisonPanel(title, fieldName, metricLabel, unit, 12, y, versionVar='version2', additionalFields=additionalFields, description=description),
+local panelPair(title, fieldName, metricLabel, unit, y, additionalFields={}, description='', axisSoftMax=null) = [
+  comparisonPanel(title, fieldName, metricLabel, unit, 0, y, versionVar='version1', additionalFields=additionalFields, description=description, axisSoftMax=axisSoftMax),
+  comparisonPanel(title, fieldName, metricLabel, unit, 12, y, versionVar='version2', additionalFields=additionalFields, description=description, axisSoftMax=axisSoftMax),
 ];
 
-local createRow(title, y) = {
+local row(title, y) = {
   type: 'row',
   title: title,
   gridPos: { h: 1, w: 24, x: 0, y: y },
 };
 
-// ─── Dashboard panels ───────────────────────────────────────────────────────
-
 local allPanels = [
-  // ── Pipeline Results ─────────────────────────────────────────
-  createRow('Pipeline Results', 0),
-] + createPanelPair(
-  'PipelineRun Succeeded',
-  '__results_PipelineRuns_count_succeeded', 'pr_succeeded', 'short', 1,
-  description='Total number of PipelineRuns that completed successfully, averaged per day per concurrency level.'
-) + createPanelPair(
-  'PipelineRun Failed',
-  '__results_PipelineRuns_count_failed', 'pr_failed', 'short', 9,
-  description='Total number of PipelineRuns that failed, averaged per day per concurrency level. A value of 0 means all runs succeeded.'
-) + createPanelPair(
-  'PR Mean Duration',
-  '__results_PipelineRuns_duration_avg', 'pr_duration', 's', 17,
-  description='Average wall-clock duration of all PipelineRuns (creationTimestamp to completionTime), per day per concurrency level.'
-) + createPanelPair(
-  'Succeeded PR Metrics (pending / running)',
-  '__results_PipelineRuns_Success_pending_avg', 'pending', 's', 25,
+  row('Pipeline Results', 0),
+] + panelPair(
+  'PipelineRun Duration (avg)',
+  '__results_PipelineRuns_duration_avg', 'pr_duration', 's', 1,
+  description='Average PipelineRun wall-clock duration. Rising trend indicates a regression.'
+) + panelPair(
+  'PipelineRun Phases (pending / running)',
+  '__results_PipelineRuns_Success_pending_avg', 'pending', 's', 9,
   additionalFields={ running: '__results_PipelineRuns_Success_running_avg' },
-  description='Breakdown of successful PipelineRun duration into two phases:\n- **pending**: time from creation to start (waiting for scheduling)\n- **running**: time from start to completion (actual execution)\n\nHigh pending time indicates scheduling pressure; high running time indicates slow task execution.'
+  description='Successful PipelineRun phase breakdown:\n- **pending**: scheduling wait\n- **running**: execution time'
+) + panelPair(
+  'PipelineRun Succeeded',
+  '__results_PipelineRuns_count_succeeded', 'pr_succeeded', 'short', 17,
+  description='Total successful PipelineRuns per day per concurrency level.'
+) + panelPair(
+  'PipelineRun Failed',
+  '__results_PipelineRuns_count_failed', 'pr_failed', 'short', 25,
+  description='Failed PipelineRuns. Should be 0.',
+  axisSoftMax=5,
 ) + [
 
-  // ── TaskRun Results ──────────────────────────────────────────
-  createRow('TaskRun Results', 33),
-] + createPanelPair(
-  'TaskRun Succeeded',
-  '__results_TaskRuns_count_succeeded', 'tr_succeeded', 'short', 34,
-  description='Total number of TaskRuns that completed successfully, averaged per day per concurrency level. Each PipelineRun creates multiple TaskRuns.'
-) + createPanelPair(
-  'TaskRun Failed',
-  '__results_TaskRuns_count_failed', 'tr_failed', 'short', 42,
-  description='Total number of TaskRuns that failed, averaged per day per concurrency level.'
-) + createPanelPair(
-  'TR Mean Success Duration',
-  '__results_TaskRuns_duration_avg', 'tr_duration', 's', 50,
-  description='Average wall-clock duration of successful TaskRuns (creationTimestamp to completionTime), per day per concurrency level.'
-) + createPanelPair(
-  'Succeeded TR Metrics (pending / running)',
-  '__results_TaskRuns_Success_pending_avg', 'pending', 's', 58,
+  row('TaskRun Results', 33),
+] + panelPair(
+  'TaskRun Duration (avg)',
+  '__results_TaskRuns_duration_avg', 'tr_duration', 's', 34,
+  description='Average successful TaskRun duration.'
+) + panelPair(
+  'TaskRun Phases (pending / running)',
+  '__results_TaskRuns_Success_pending_avg', 'pending', 's', 42,
   additionalFields={ running: '__results_TaskRuns_Success_running_avg' },
-  description='Breakdown of successful TaskRun duration into two phases:\n- **pending**: time from creation to start (waiting for Pod scheduling)\n- **running**: time from start to completion (actual container execution)\n\nHigh pending time indicates Pod scheduling delays or resource pressure.'
+  description='Successful TaskRun phase breakdown:\n- **pending**: Pod scheduling wait\n- **running**: container execution time'
+) + panelPair(
+  'TaskRun Succeeded',
+  '__results_TaskRuns_count_succeeded', 'tr_succeeded', 'short', 50,
+  description='Total successful TaskRuns per day per concurrency level.'
+) + panelPair(
+  'TaskRun Failed',
+  '__results_TaskRuns_count_failed', 'tr_failed', 'short', 58,
+  description='Failed TaskRuns. Should be 0.',
+  axisSoftMax=5,
 ) + [
 
-  // ── Controller Metrics ───────────────────────────────────────
-  createRow('Controller Metrics', 66),
-] + createPanelPair(
-  'TaskRun to Pod Creation Duration',
+  row('Controller Health', 66),
+] + panelPair(
+  'TaskRun → Pod Creation Lag',
   '__results_TaskRunsToPods_creationTimestampDiff_mean', 'pod_creation_lag', 's', 67,
-  description='Mean time between TaskRun creation and its corresponding Pod creation. Measures how long the Tekton controller takes to reconcile a TaskRun and create the Pod. High values indicate controller backlog.'
-) + createPanelPair(
-  'Controllers CPU Usage (Mean)',
-  '__measurements_tektonPipelinesController_cpu_mean', 'controller_cpu', 'short', 75,
+  description='Mean time from TaskRun creation to Pod creation. High values indicate controller backlog.'
+) + panelPair(
+  'Controller Workqueue Depth',
+  '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean', 'workqueue_depth', 'short', 75,
+  description='Controller work queue depth. High = bottleneck.'
+) + panelPair(
+  'Controller Client Latency',
+  '__measurements_tektonPipelinesControllerClientLatencyAverage_mean', 'client_latency', 's', 83,
+  description='Controller → API server HTTP latency.'
+) + [
+
+  row('Component Resources', 91),
+] + panelPair(
+  'Tekton CPU (controller / webhook / proxy)',
+  '__measurements_tektonPipelinesController_cpu_mean', 'controller_cpu', 'short', 92,
   additionalFields={
     webhook_cpu: '__measurements_tektonPipelinesWebhook_cpu_mean',
-    proxy_webhook_cpu: '__measurements_tektonOperatorProxyWebhook_cpu_mean',
+    proxy_cpu: '__measurements_tektonOperatorProxyWebhook_cpu_mean',
   },
-  description='Mean CPU usage of Tekton Pipelines components during the test run, in CPU cores (e.g. 0.06 = 60 millicores).\n- **controller_cpu**: main reconciliation controller\n- **webhook_cpu**: admission webhook\n- **proxy_webhook_cpu**: operator proxy webhook'
-) + createPanelPair(
-  'Controllers Memory Usage (Mean)',
-  '__measurements_tektonPipelinesController_memory_mean', 'controller_mem', 'bytes', 83,
+  description='Mean CPU of Tekton Pipelines components (cores).\n- **controller_cpu**: reconciliation loop\n- **webhook_cpu**: admission webhook\n- **proxy_cpu**: operator proxy webhook'
+) + panelPair(
+  'Tekton Memory (controller / webhook / proxy)',
+  '__measurements_tektonPipelinesController_memory_mean', 'controller_mem', 'bytes', 100,
   additionalFields={
     webhook_mem: '__measurements_tektonPipelinesWebhook_memory_mean',
-    proxy_webhook_mem: '__measurements_tektonOperatorProxyWebhook_memory_mean',
+    proxy_mem: '__measurements_tektonOperatorProxyWebhook_memory_mean',
   },
-  description='Mean memory (RSS) usage of Tekton Pipelines components during the test run.\n- **controller_mem**: main reconciliation controller\n- **webhook_mem**: admission webhook\n- **proxy_webhook_mem**: operator proxy webhook'
-) + createPanelPair(
-  'Pipelines Controller Workqueue Depth',
-  '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean', 'workqueue_depth', 'short', 91,
-  description='Mean depth of the Tekton Pipelines controller workqueue during the test. A growing workqueue indicates the controller cannot reconcile objects fast enough. Consistently high values suggest the controller is a bottleneck.\n\nNote: Nightly builds using Tekton >= v1.10 report this as kn_workqueue_depth (OpenTelemetry).'
-) + createPanelPair(
-  'Pipelines Controller Client Latency',
-  '__measurements_tektonPipelinesControllerClientLatencyAverage_mean', 'client_latency', 's', 99,
-  description='Mean HTTP client latency (p50) of the Tekton Pipelines controller when communicating with the Kubernetes API server. High latency indicates API server pressure or network issues.\n\nNote: Nightly builds using Tekton >= v1.10 report this as http_client_request_duration_seconds (OpenTelemetry).'
+  description='Mean memory (RSS) of Tekton Pipelines components.\n- **controller_mem**: reconciliation loop\n- **webhook_mem**: admission webhook\n- **proxy_mem**: operator proxy webhook'
 ) + [
 
-  // ── Cluster & API Server Metrics ─────────────────────────────
-  createRow('Cluster & API Server Metrics', 107),
-] + createPanelPair(
-  'Cluster CPU Usage',
-  '__measurements_clusterCpuUsageSecondsTotalRate_mean', 'cluster_cpu', 'short', 108,
-  description='Mean total CPU usage rate across all cluster nodes during the test run, in CPU cores.'
-) + createPanelPair(
-  'Cluster Memory Usage',
-  '__measurements_clusterMemoryUsageRssTotal_mean', 'cluster_mem', 'bytes', 116,
-  description='Mean total RSS memory usage across all cluster nodes during the test run.'
-) + createPanelPair(
-  'OpenShift and Kube API Server CPU Usage (Mean)',
-  '__measurements_apiserver_cpu_mean', 'apiserver_cpu', 'short', 124,
+  row('Cluster & API Server', 108),
+] + panelPair(
+  'Cluster CPU',
+  '__measurements_clusterCpuUsageSecondsTotalRate_mean', 'cluster_cpu', 'short', 109,
+  description='Mean total cluster CPU usage rate (cores).'
+) + panelPair(
+  'Cluster Memory',
+  '__measurements_clusterMemoryUsageRssTotal_mean', 'cluster_mem', 'bytes', 117,
+  description='Mean total cluster RSS memory.'
+) + panelPair(
+  'API Server CPU (OpenShift / Kube)',
+  '__measurements_apiserver_cpu_mean', 'ocp_apiserver_cpu', 'short', 125,
   additionalFields={ kube_apiserver_cpu: '__measurements_kubeApiserver_cpu_mean' },
-  description='Mean CPU usage of the OpenShift API server and Kubernetes API server during the test run.\n- **apiserver_cpu**: openshift-apiserver\n- **kube_apiserver_cpu**: kube-apiserver'
-) + createPanelPair(
-  'OpenShift and Kube API Server Memory Usage (Mean)',
-  '__measurements_apiserver_memory_mean', 'apiserver_mem', 'bytes', 132,
+  description='Mean API server CPU (cores).'
+) + panelPair(
+  'API Server Memory (OpenShift / Kube)',
+  '__measurements_apiserver_memory_mean', 'ocp_apiserver_mem', 'bytes', 133,
   additionalFields={ kube_apiserver_mem: '__measurements_kubeApiserver_memory_mean' },
-  description='Mean memory (RSS) usage of the OpenShift API server and Kubernetes API server during the test run.\n- **apiserver_mem**: openshift-apiserver\n- **kube_apiserver_mem**: kube-apiserver'
+  description='Mean API server memory.'
 ) + [
 
-  // ── etcd Metrics ──────────────────────────────────────────────
-  createRow('etcd Metrics', 140),
-] + createPanelPair(
-  'etcd MVCC DB Size (Mean)',
-  '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean', 'db_total', 'bytes', 141,
+  row('etcd', 141),
+] + panelPair(
+  'etcd DB Size (total / in-use)',
+  '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean', 'db_total', 'bytes', 142,
   additionalFields={ db_in_use: '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean' },
-  description='Mean etcd MVCC database size during the test run.\n- **db_total**: total allocated size on disk\n- **db_in_use**: logical size of live data\n\nA large gap between total and in-use indicates fragmentation; an etcd defrag may be needed.'
-) + createPanelPair(
-  'etcd Request Duration (Mean)',
-  '__measurements_etcdRequestDurationSecondsAverage_mean', 'req_duration_mean', 's', 149,
-  additionalFields={ req_duration_max: '__measurements_etcdRequestDurationSecondsAverage_max' },
-  description='Mean and peak etcd request durations during the test run.\n- **req_duration_mean**: average latency per request\n- **req_duration_max**: worst-case latency observed\n\nHigh values indicate etcd pressure, disk I/O issues, or large key-value operations.'
-) + createPanelPair(
+  description='etcd MVCC DB size.\n- **db_total**: allocated on disk\n- **db_in_use**: live data'
+) + panelPair(
+  'etcd Request Duration (mean / max)',
+  '__measurements_etcdRequestDurationSecondsAverage_mean', 'mean', 's', 150,
+  additionalFields={ max: '__measurements_etcdRequestDurationSecondsAverage_max' },
+  description='etcd request latency.\n- **mean**: average\n- **max**: worst-case peak'
+) + panelPair(
   'etcd Restarts',
-  '__measurements_etcd_restarts_range', 'etcd_restarts', 'short', 157,
-  description='Number of etcd Pod restarts during the test run. Should be 0 under normal conditions. Restarts indicate OOM kills, liveness probe failures, or cluster instability.'
-) + createPanelPair(
+  '__measurements_etcd_restarts_range', 'etcd_restarts', 'short', 158,
+  description='etcd Pod restarts. Should be 0.',
+  axisSoftMax=5,
+) + panelPair(
   'Scheduler Pending Pods',
-  '__measurements_schedulerPendingPodsCount_range', 'pending_pods', 'short', 165,
-  description='Range of pending pods in the kube-scheduler queue during the test run. High values indicate scheduling pressure caused by insufficient node resources or excessive Pod creation rate.'
+  '__measurements_schedulerPendingPodsCount_range', 'pending_pods', 'short', 166,
+  description='Pending pods in kube-scheduler queue.',
+  axisSoftMax=5,
 );
 
-// ─── Dashboard ──────────────────────────────────────────────────────────────
-
-dashboard.new('Pipelines Performance Comparison Dashboard')
+dashboard.new('Pipelines Performance Comparison')
 + dashboard.withUid('Pipelines_Performance_Comparison')
-+ dashboard.withDescription('Side-by-side comparison of OpenShift Pipelines performance metrics across different released versions. Select two versions to compare.')
++ dashboard.withDescription('Side-by-side comparison of two versions for the same variant. Select a variant, pick two versions, and see their metrics mirrored left/right. Includes historical data from legacy test 391.')
 + dashboard.time.withFrom('now-30d')
 + dashboard.time.withTo('now')
 + dashboard.withTimezone('utc')
 + dashboard.withRefresh('5m')
-+ dashboard.withVariables([datasourceVar, deployConfigVar, version1Var, version2Var, concurrencyVar])
++ dashboard.withVariables([datasourceVar, variantVar, version1Var, version2Var, concurrencyVar])
 + dashboard.withPanels(allPanels)
 + dashboard.withEditable(true)
-+ dashboard.graphTooltip.withSharedCrosshair()
++ dashboard.withTags(['pipelines', 'comparison', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()

--- a/config/grafonnet-workdir/src/pipelines-dashboard.jsonnet
+++ b/config/grafonnet-workdir/src/pipelines-dashboard.jsonnet
@@ -1,38 +1,26 @@
 local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/pipelines-common.libsonnet';
 
 local dashboard = grafonnet.dashboard;
 local timeSeries = grafonnet.panel.timeSeries;
 
-// ─── Constants ───────────────────────────────────────────────────────────────
-local testId = 391;
+local versionExpr = common.versionExpr;
+local testIdPredicate = common.testIdPredicate;
+local datasourceVar = common.datasourceVar;
+local variantVar = common.variantVar;
 
-// ─── Template variables ─────────────────────────────────────────────────────
-local datasourceVar =
-  grafonnet.dashboard.variable.datasource.new(
-    'datasource',
-    'grafana-postgresql-datasource',
-  )
-  + grafonnet.dashboard.variable.datasource.withRegex('.*grafana-postgresql-datasource.*')
-  + grafonnet.dashboard.variable.custom.generalOptions.withLabel('Datasource')
-  + grafonnet.dashboard.variable.custom.generalOptions.withDescription('PostgreSQL datasource for pipeline metrics')
-  + grafonnet.dashboard.variable.custom.generalOptions.withCurrent('grafana-postgresql-datasource');
-
-local deployConfigVar = {
-  type: 'custom',
-  name: 'deploy_config',
-  label: 'Deployment Configuration',
-  description: 'Standard, HA (no QBT), QBT (non-HA), or HA+QBT (deployments only). Dashboard shows nightly builds only.',
-  query: 'Standard : standard,HA - Deployments : ha-deployments,HA - StatefulSets : ha-statefulsets,QBT (non-HA) : qbt,HA + QBT - Deployments : ha-qbt-deployments',
+local versionVar = {
+  type: 'query',
+  name: 'version',
+  label: 'Version',
+  description: 'Filter to a specific version to track its trend over time.',
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: "SELECT DISTINCT %s AS version FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testIdPredicate],
   multi: false,
   includeAll: false,
-  current: { text: 'Standard', value: 'standard' },
-  options: [
-    { text: 'Standard', value: 'standard', selected: true },
-    { text: 'HA - Deployments', value: 'ha-deployments', selected: false },
-    { text: 'HA - StatefulSets', value: 'ha-statefulsets', selected: false },
-    { text: 'QBT (non-HA)', value: 'qbt', selected: false },
-    { text: 'HA + QBT - Deployments', value: 'ha-qbt-deployments', selected: false },
-  ],
+  current: { text: 'nightly', value: 'nightly' },
+  refresh: 2,
+  sort: 0,
 };
 
 local concurrencyVar = {
@@ -41,7 +29,7 @@ local concurrencyVar = {
   label: 'Concurrency',
   description: 'Filter by concurrency level. Select one or more, or All.',
   datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
-  query: "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE horreum_testid = %g AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency" % testId,
+  query: "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency" % testIdPredicate,
   multi: true,
   includeAll: true,
   current: { text: 'All', value: '$__all' },
@@ -49,30 +37,14 @@ local concurrencyVar = {
   sort: 3,
 };
 
-// ─── SQL predicates (injected into every query) ─────────────────────────────
-
-local nightlyOnlyPredicate = |||
-        AND (label_values ? '__deployment_nightly')
-        AND (label_values->>'__deployment_nightly')::BOOLEAN = true
-|||;
-
-local deployConfigPredicate = |||
-        AND (
-          ('$deploy_config' = 'standard' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'ha-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'ha-statefulsets' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'statefulSets' AND (NOT (label_values ? '__deployment_qbtConfig_qbtEnabled') OR (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = false))
-          OR ('$deploy_config' = 'qbt' AND (NOT (label_values ? '__deployment_haConfig_haEnabled') OR (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = false) AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
-          OR ('$deploy_config' = 'ha-qbt-deployments' AND (label_values->>'__deployment_haConfig_haEnabled')::BOOLEAN = true AND (label_values->>'__deployment_haConfig_controllerType') = 'deployments' AND (label_values ? '__deployment_qbtConfig_qbtEnabled') AND (label_values->>'__deployment_qbtConfig_qbtEnabled')::BOOLEAN = true)
-        )
-|||;
+local versionPredicate = |||
+        AND %s = '${version}'
+||| % versionExpr;
 
 local concurrencyPredicate = |||
         AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)
 |||;
 
-// ─── Query builders ─────────────────────────────────────────────────────────
-
-// Daily-aggregated query with automatic UNION ALL for multi-field panels
 local createComplexQuery(fieldName, metricLabel, additionalFields={}) =
   local baseFields = { [metricLabel]: fieldName };
   local allFields = baseFields + additionalFields;
@@ -88,7 +60,7 @@ local createComplexQuery(fieldName, metricLabel, additionalFields={}) =
     |||
       SELECT
         EXTRACT(EPOCH FROM day) AS time,
-        '%s @ ' || concurrency AS metric,
+        '%s @ c' || concurrency AS metric,
         %s AS value
       FROM daily_agg
     ||| % [key, key]
@@ -103,9 +75,8 @@ local createComplexQuery(fieldName, metricLabel, additionalFields={}) =
           (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,
           %s
         FROM data
-        WHERE horreum_testid = %g
+        WHERE %s
           AND $__timeFilter(start)
-          %s
           %s
           %s
           AND %s
@@ -115,14 +86,12 @@ local createComplexQuery(fieldName, metricLabel, additionalFields={}) =
       %s
 
       ORDER BY time, metric;
-    ||| % [fieldSelections, testId, concurrencyPredicate, deployConfigPredicate, nightlyOnlyPredicate, fieldConditions, selectStatements],
+    ||| % [fieldSelections, testIdPredicate, concurrencyPredicate, versionPredicate, fieldConditions, selectStatements],
     format: 'time_series',
     refId: 'A',
   };
 
-// ─── Panel builders ─────────────────────────────────────────────────────────
-
-local createComplexPanel(title, fieldName, metricLabel, unit='short', gridX=0, gridY=0, gridW=12, gridH=8, additionalFields={}, description='') =
+local trendPanel(title, fieldName, metricLabel, unit='short', gridX=0, gridY=0, gridW=12, gridH=8, additionalFields={}, description='', axisSoftMax=null) =
   timeSeries.new(title)
   + timeSeries.queryOptions.withDatasource(type='grafana-postgresql-datasource', uid='${datasource}')
   + (if description != '' then timeSeries.panelOptions.withDescription(description) else {})
@@ -131,233 +100,242 @@ local createComplexPanel(title, fieldName, metricLabel, unit='short', gridX=0, g
   + timeSeries.gridPos.withW(gridW)
   + timeSeries.gridPos.withH(gridH)
   + timeSeries.fieldConfig.defaults.custom.withDrawStyle('line')
-  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(0)
+  + timeSeries.fieldConfig.defaults.custom.withLineWidth(2)
+  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(8)
+  + timeSeries.fieldConfig.defaults.custom.withGradientMode('opacity')
   + timeSeries.fieldConfig.defaults.custom.withSpanNulls(false)
   + timeSeries.fieldConfig.defaults.custom.withShowPoints('always')
-  + timeSeries.fieldConfig.defaults.custom.withPointSize(7)
+  + timeSeries.fieldConfig.defaults.custom.withPointSize(6)
   + timeSeries.standardOptions.withUnit(unit)
   + timeSeries.standardOptions.withMin(0)
+  + timeSeries.options.withTooltip({ mode: 'multi', sort: 'desc' })
+  + timeSeries.options.withLegend({ displayMode: 'list', placement: 'bottom', calcs: [] })
+  + (if axisSoftMax != null then { fieldConfig+: { defaults+: { custom+: { axisSoftMax: axisSoftMax } } } } else {})
   + timeSeries.queryOptions.withTargets([
     createComplexQuery(fieldName, metricLabel, additionalFields),
   ]);
 
-local createRow(title, y) = {
+local row(title, y) = {
   type: 'row',
   title: title,
   gridPos: { h: 1, w: 24, x: 0, y: y },
 };
 
-// ─── Dashboard panels ───────────────────────────────────────────────────────
-
 local allPanels = [
   // ── Pipeline Results ─────────────────────────────────────────
-  createRow('Pipeline Results', 0),
-  createComplexPanel(
+  row('Pipeline Results', 0),
+  trendPanel(
+    'PipelineRun Duration (avg)',
+    '__results_PipelineRuns_duration_avg',
+    'pr_duration',
+    's',
+    0, 1, 12, 8,
+    description='Average wall-clock duration of all PipelineRuns (creationTimestamp → completionTime), per day per concurrency level. Rising trend indicates a regression.'
+  ),
+  trendPanel(
+    'PipelineRun Phases (pending / running)',
+    '__results_PipelineRuns_Success_pending_avg',
+    'pending',
+    's',
+    12, 1, 12, 8,
+    { running: '__results_PipelineRuns_Success_running_avg' },
+    description='Breakdown of successful PipelineRun duration into two phases:\n- **pending**: time from creation to start (waiting for scheduling)\n- **running**: time from start to completion (actual execution)\n\nHigh pending → scheduling pressure. High running → slow task execution.'
+  ),
+  trendPanel(
     'PipelineRun Succeeded',
     '__results_PipelineRuns_count_succeeded',
     'pr_succeeded',
     'short',
-    0, 1, 12, 8,
+    0, 9, 12, 8,
     description='Total number of PipelineRuns that completed successfully, averaged per day per concurrency level.'
   ),
-  createComplexPanel(
+  trendPanel(
     'PipelineRun Failed',
     '__results_PipelineRuns_count_failed',
     'pr_failed',
     'short',
-    12, 1, 12, 8,
-    description='Total number of PipelineRuns that failed, averaged per day per concurrency level. A value of 0 means all runs succeeded.'
-  ),
-  createComplexPanel(
-    'PR Mean Duration',
-    '__results_PipelineRuns_duration_avg',
-    'pr_duration',
-    's',
-    0, 9, 12, 8,
-    description='Average wall-clock duration of all PipelineRuns (creationTimestamp to completionTime), per day per concurrency level.'
-  ),
-  createComplexPanel(
-    'Succeeded PR Metrics (pending / running)',
-    '__results_PipelineRuns_Success_pending_avg',
-    'pending',
-    's',
     12, 9, 12, 8,
-    { running: '__results_PipelineRuns_Success_running_avg' },
-    description='Breakdown of successful PipelineRun duration into two phases:\n- **pending**: time from creation to start (waiting for scheduling)\n- **running**: time from start to completion (actual execution)\n\nHigh pending time indicates scheduling pressure; high running time indicates slow task execution.'
+    description='PipelineRuns that failed. Should be 0. Any non-zero value indicates test failures worth investigating.',
+    axisSoftMax=5,
   ),
 
   // ── TaskRun Results ──────────────────────────────────────────
-  createRow('TaskRun Results', 17),
-  createComplexPanel(
+  row('TaskRun Results', 17),
+  trendPanel(
+    'TaskRun Duration (avg)',
+    '__results_TaskRuns_duration_avg',
+    'tr_duration',
+    's',
+    0, 18, 12, 8,
+    description='Average wall-clock duration of successful TaskRuns (creationTimestamp → completionTime), per day per concurrency level.'
+  ),
+  trendPanel(
+    'TaskRun Phases (pending / running)',
+    '__results_TaskRuns_Success_pending_avg',
+    'pending',
+    's',
+    12, 18, 12, 8,
+    { running: '__results_TaskRuns_Success_running_avg' },
+    description='Breakdown of successful TaskRun duration into two phases:\n- **pending**: time from creation to start (waiting for Pod scheduling)\n- **running**: time from start to completion (actual container execution)\n\nHigh pending → Pod scheduling delays or resource pressure.'
+  ),
+  trendPanel(
     'TaskRun Succeeded',
     '__results_TaskRuns_count_succeeded',
     'tr_succeeded',
     'short',
-    0, 18, 12, 8,
+    0, 26, 12, 8,
     description='Total number of TaskRuns that completed successfully, averaged per day per concurrency level. Each PipelineRun creates multiple TaskRuns.'
   ),
-  createComplexPanel(
+  trendPanel(
     'TaskRun Failed',
     '__results_TaskRuns_count_failed',
     'tr_failed',
     'short',
-    12, 18, 12, 8,
-    description='Total number of TaskRuns that failed, averaged per day per concurrency level.'
-  ),
-  createComplexPanel(
-    'TR Mean Success Duration',
-    '__results_TaskRuns_duration_avg',
-    'tr_duration',
-    's',
-    0, 26, 12, 8,
-    description='Average wall-clock duration of successful TaskRuns (creationTimestamp to completionTime), per day per concurrency level.'
-  ),
-  createComplexPanel(
-    'Succeeded TR Metrics (pending / running)',
-    '__results_TaskRuns_Success_pending_avg',
-    'pending',
-    's',
     12, 26, 12, 8,
-    { running: '__results_TaskRuns_Success_running_avg' },
-    description='Breakdown of successful TaskRun duration into two phases:\n- **pending**: time from creation to start (waiting for Pod scheduling)\n- **running**: time from start to completion (actual container execution)\n\nHigh pending time indicates Pod scheduling delays or resource pressure.'
+    description='TaskRuns that failed. Should be 0.',
+    axisSoftMax=5,
   ),
 
-  // ── Controller Metrics ───────────────────────────────────────
-  createRow('Controller Metrics', 34),
-  createComplexPanel(
-    'TaskRun to Pod Creation Duration',
+  // ── Controller Health ──────────────────────────────────────────
+  row('Controller Health', 34),
+  trendPanel(
+    'TaskRun → Pod Creation Lag',
     '__results_TaskRunsToPods_creationTimestampDiff_mean',
     'pod_creation_lag',
     's',
     0, 35, 12, 8,
     description='Mean time between TaskRun creation and its corresponding Pod creation. Measures how long the Tekton controller takes to reconcile a TaskRun and create the Pod. High values indicate controller backlog.'
   ),
-  createComplexPanel(
-    'Controllers CPU Usage (Mean)',
-    '__measurements_tektonPipelinesController_cpu_mean',
-    'controller_cpu',
-    'short',
-    12, 35, 12, 8,
-    {
-      webhook_cpu: '__measurements_tektonPipelinesWebhook_cpu_mean',
-      proxy_webhook_cpu: '__measurements_tektonOperatorProxyWebhook_cpu_mean',
-    },
-    description='Mean CPU usage of Tekton Pipelines components during the test run, in CPU cores (e.g. 0.06 = 60 millicores).\n- **controller_cpu**: main reconciliation controller\n- **webhook_cpu**: admission webhook\n- **proxy_webhook_cpu**: operator proxy webhook'
-  ),
-  createComplexPanel(
-    'Controllers Memory Usage (Mean)',
-    '__measurements_tektonPipelinesController_memory_mean',
-    'controller_mem',
-    'bytes',
-    0, 43, 12, 8,
-    {
-      webhook_mem: '__measurements_tektonPipelinesWebhook_memory_mean',
-      proxy_webhook_mem: '__measurements_tektonOperatorProxyWebhook_memory_mean',
-    },
-    description='Mean memory (RSS) usage of Tekton Pipelines components during the test run.\n- **controller_mem**: main reconciliation controller\n- **webhook_mem**: admission webhook\n- **proxy_webhook_mem**: operator proxy webhook'
-  ),
-  createComplexPanel(
-    'Pipelines Controller Workqueue Depth',
+  trendPanel(
+    'Controller Workqueue Depth',
     '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean',
     'workqueue_depth',
     'short',
-    12, 43, 12, 8,
-    description='Mean depth of the Tekton Pipelines controller workqueue during the test. A growing workqueue indicates the controller cannot reconcile objects fast enough. Consistently high values suggest the controller is a bottleneck.\n\nNote: Nightly builds using Tekton >= v1.10 report this as kn_workqueue_depth (OpenTelemetry).'
+    12, 35, 12, 8,
+    description='Mean depth of the Tekton Pipelines controller work queue. A growing queue means the controller cannot reconcile objects fast enough.\n\nNote: Tekton >= v1.10 reports this as kn_workqueue_depth (OpenTelemetry).'
   ),
-  createComplexPanel(
-    'Pipelines Controller Client Latency',
+  trendPanel(
+    'Controller Client Latency',
     '__measurements_tektonPipelinesControllerClientLatencyAverage_mean',
     'client_latency',
     's',
-    0, 51, 12, 8,
-    description='Mean HTTP client latency (p50) of the Tekton Pipelines controller when communicating with the Kubernetes API server. High latency indicates API server pressure or network issues.\n\nNote: Nightly builds using Tekton >= v1.10 report this as http_client_request_duration_seconds (OpenTelemetry).'
+    0, 43, 12, 8,
+    description='Mean HTTP client latency of the Tekton Pipelines controller when communicating with the Kubernetes API server. High latency indicates API server pressure or network issues.\n\nNote: Tekton >= v1.10 reports this as http_client_request_duration_seconds (OpenTelemetry).'
   ),
 
-  // ── Cluster & API Server Metrics ─────────────────────────────
-  createRow('Cluster & API Server Metrics', 59),
-  createComplexPanel(
-    'Cluster CPU Usage',
+  // ── Component Resources ────────────────────────────────────────
+  row('Component Resources', 51),
+  trendPanel(
+    'Tekton CPU (controller / webhook / proxy)',
+    '__measurements_tektonPipelinesController_cpu_mean',
+    'controller_cpu',
+    'short',
+    0, 52, 12, 8,
+    {
+      webhook_cpu: '__measurements_tektonPipelinesWebhook_cpu_mean',
+      proxy_cpu: '__measurements_tektonOperatorProxyWebhook_cpu_mean',
+    },
+    description='Mean CPU usage of Tekton Pipelines components (in CPU cores, e.g. 0.06 = 60 millicores).\n- **controller_cpu**: main reconciliation loop\n- **webhook_cpu**: admission webhook\n- **proxy_cpu**: operator proxy webhook'
+  ),
+  trendPanel(
+    'Tekton Memory (controller / webhook / proxy)',
+    '__measurements_tektonPipelinesController_memory_mean',
+    'controller_mem',
+    'bytes',
+    12, 52, 12, 8,
+    {
+      webhook_mem: '__measurements_tektonPipelinesWebhook_memory_mean',
+      proxy_mem: '__measurements_tektonOperatorProxyWebhook_memory_mean',
+    },
+    description='Mean memory (RSS) usage of Tekton Pipelines components.\n- **controller_mem**: main reconciliation loop\n- **webhook_mem**: admission webhook\n- **proxy_mem**: operator proxy webhook'
+  ),
+
+  // ── Cluster & API Server ───────────────────────────────────────
+  row('Cluster & API Server', 60),
+  trendPanel(
+    'Cluster CPU',
     '__measurements_clusterCpuUsageSecondsTotalRate_mean',
     'cluster_cpu',
     'short',
-    0, 60, 12, 8,
-    description='Mean total CPU usage rate across all cluster nodes during the test run, in CPU cores (e.g. 6.5 = 6.5 cores used across the cluster).'
+    0, 61, 12, 8,
+    description='Mean total CPU usage rate across all cluster nodes during the test, in CPU cores.'
   ),
-  createComplexPanel(
-    'Cluster Memory Usage',
+  trendPanel(
+    'Cluster Memory',
     '__measurements_clusterMemoryUsageRssTotal_mean',
     'cluster_mem',
     'bytes',
-    12, 60, 12, 8,
-    description='Mean total RSS memory usage across all cluster nodes during the test run.'
+    12, 61, 12, 8,
+    description='Mean total RSS memory usage across all cluster nodes during the test.'
   ),
-  createComplexPanel(
-    'OpenShift and Kube API Server CPU Usage (Mean)',
+  trendPanel(
+    'API Server CPU (OpenShift / Kube)',
     '__measurements_apiserver_cpu_mean',
-    'apiserver_cpu',
+    'ocp_apiserver_cpu',
     'short',
-    0, 68, 12, 8,
+    0, 69, 12, 8,
     { kube_apiserver_cpu: '__measurements_kubeApiserver_cpu_mean' },
-    description='Mean CPU usage of the OpenShift API server and Kubernetes API server during the test run, in CPU cores. High values may indicate excessive API calls from the Tekton controller or other components.'
+    description='Mean CPU usage of the OpenShift and Kubernetes API servers (in CPU cores). High values may indicate excessive API calls from Tekton or other components.'
   ),
-  createComplexPanel(
-    'OpenShift and Kube API Server Memory Usage (Mean)',
+  trendPanel(
+    'API Server Memory (OpenShift / Kube)',
     '__measurements_apiserver_memory_mean',
-    'apiserver_mem',
+    'ocp_apiserver_mem',
     'bytes',
-    12, 68, 12, 8,
+    12, 69, 12, 8,
     { kube_apiserver_mem: '__measurements_kubeApiserver_memory_mean' },
-    description='Mean memory usage of the OpenShift API server and Kubernetes API server during the test run.'
+    description='Mean memory usage of the OpenShift and Kubernetes API servers.'
   ),
 
-  // ── etcd Metrics ──────────────────────────────────────────────
-  createRow('etcd Metrics', 76),
-  createComplexPanel(
-    'etcd MVCC DB Size (Mean)',
+  // ── etcd ──────────────────────────────────────────────────────
+  row('etcd', 77),
+  trendPanel(
+    'etcd DB Size (total / in-use)',
     '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean',
     'db_total',
     'bytes',
-    0, 77, 12, 8,
+    0, 78, 12, 8,
     { db_in_use: '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean' },
-    description='Mean etcd MVCC database size during the test run.\n- **db_total**: total allocated DB size on disk\n- **db_in_use**: portion of the DB actively in use\n\nA large gap between total and in-use may indicate fragmentation or the need for defragmentation.'
+    description='Mean etcd MVCC database size.\n- **db_total**: total allocated DB size on disk\n- **db_in_use**: portion actively in use\n\nA large gap between the two may indicate fragmentation.'
   ),
-  createComplexPanel(
-    'etcd Request Duration (Mean)',
+  trendPanel(
+    'etcd Request Duration (mean / max)',
     '__measurements_etcdRequestDurationSecondsAverage_mean',
-    'req_duration_mean',
+    'mean',
     's',
-    12, 77, 12, 8,
-    { req_duration_max: '__measurements_etcdRequestDurationSecondsAverage_max' },
-    description='Average and maximum etcd request duration during the test run.\n- **req_duration_mean**: average latency across all etcd requests\n- **req_duration_max**: worst-case (peak) etcd request latency\n\nHigh values indicate etcd is under pressure, which can cause slow reconciliation and API server latency.'
+    12, 78, 12, 8,
+    { max: '__measurements_etcdRequestDurationSecondsAverage_max' },
+    description='etcd request latency.\n- **mean**: average across all requests\n- **max**: worst-case peak latency\n\nHigh values indicate etcd pressure, causing slow reconciliation and API latency.'
   ),
-  createComplexPanel(
+  trendPanel(
     'etcd Restarts',
     '__measurements_etcd_restarts_range',
     'etcd_restarts',
     'short',
-    0, 85, 12, 8,
-    description='Number of etcd Pod restarts during the test run. Should be 0 under normal conditions. Any restarts indicate instability that likely affected test results.'
+    0, 86, 12, 8,
+    description='etcd Pod restarts during the test. Should be 0. Any restarts indicate instability that likely affected results.',
+    axisSoftMax=5,
   ),
-  createComplexPanel(
+  trendPanel(
     'Scheduler Pending Pods',
     '__measurements_schedulerPendingPodsCount_range',
     'pending_pods',
     'short',
-    12, 85, 12, 8,
-    description='Range of pending pods count in the Kubernetes scheduler during the test run. High values indicate scheduling pressure — pods are waiting for resources or node availability.'
+    12, 86, 12, 8,
+    description='Range of pending pods in the kube-scheduler queue. High values indicate scheduling pressure — pods waiting for resources or node availability.',
+    axisSoftMax=5,
   ),
 ];
 
-// ─── Dashboard ──────────────────────────────────────────────────────────────
-
 dashboard.new('Pipelines Performance Dashboard')
 + dashboard.withUid('Pipelines_Performance')
-+ dashboard.withDescription('OpenShift Pipelines nightly build performance. Use the Deployment Configuration variable to switch between Standard, HA, QBT, and HA+QBT setups.')
++ dashboard.withDescription('OpenShift Pipelines performance trends per variant and version. Includes historical data from legacy test 391 and new per-variant tests (419-423). Select a variant, version, and concurrency level to track regressions over time.')
 + dashboard.time.withFrom('now-30d')
 + dashboard.time.withTo('now')
 + dashboard.withTimezone('utc')
 + dashboard.withRefresh('5m')
-+ dashboard.withVariables([datasourceVar, deployConfigVar, concurrencyVar])
++ dashboard.withVariables([datasourceVar, variantVar, versionVar, concurrencyVar])
 + dashboard.withPanels(allPanels)
 + dashboard.withEditable(true)
-+ dashboard.graphTooltip.withSharedCrosshair()
++ dashboard.withTags(['pipelines', 'trend', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()

--- a/config/grafonnet-workdir/src/pipelines-version-comparison-v2.jsonnet
+++ b/config/grafonnet-workdir/src/pipelines-version-comparison-v2.jsonnet
@@ -1,0 +1,153 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/pipelines-common.libsonnet';
+local versionBarLib = import 'lib/version-bar-common.libsonnet';
+
+local dashboard = grafonnet.dashboard;
+
+local versionExpr = common.versionExpr;
+local testIdPredicate = common.testIdPredicate;
+local datasourceVar = common.datasourceVar;
+local variantVar = common.variantVar;
+
+local versionVar = {
+  type: 'query',
+  name: 'version',
+  label: 'Version',
+  description: 'Select versions to compare. Use All to include every version.',
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: "SELECT DISTINCT %s AS version FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testIdPredicate],
+  multi: true,
+  includeAll: true,
+  current: { text: 'All', value: '$__all' },
+  refresh: 2,
+  sort: 0,
+};
+
+local concurrencyVar = {
+  type: 'query',
+  name: 'concurrency',
+  label: 'Concurrency',
+  description: 'Select a single concurrency level to compare versions at.',
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE %s AND $__timeFilter(start) AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency" % testIdPredicate,
+  multi: false,
+  includeAll: false,
+  current: { text: '1', value: '1' },
+  refresh: 2,
+  sort: 3,
+};
+
+local createQuery(fieldName, agg='AVG') =
+  {
+    rawSql: |||
+      WITH daily AS (
+        SELECT
+          TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,
+          DATE_TRUNC('day', start) AS day_date,
+          %s AS version,
+          (label_values->>'%s')::DOUBLE PRECISION AS val
+        FROM data
+        WHERE %s
+          AND $__timeFilter(start)
+          AND %s IN ($version)
+          AND (label_values->>'__parameters_test_concurrent')::INTEGER = ${concurrency}::INTEGER
+          AND label_values ? '%s'
+      )
+      SELECT day, version, %s(val) AS value
+      FROM daily
+      GROUP BY day, version
+      ORDER BY MIN(day_date),
+        CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,
+        version ASC
+    ||| % [versionExpr, fieldName, testIdPredicate, versionExpr, fieldName, agg],
+    format: 'table',
+    refId: 'A',
+  };
+
+local row = versionBarLib.row;
+
+local versionBar(title, fieldName, unit, x, y, w, h, description='', agg='AVG', axisSoftMax=null) =
+  versionBarLib.versionBar(createQuery, title, fieldName, unit, x, y, w, h, description, agg, axisSoftMax);
+
+local pw = 24;
+local ph = 8;
+
+local allPanels = [
+
+  row('Pipeline Performance', 0),
+  versionBar('PipelineRun Duration (avg)', '__results_PipelineRuns_duration_avg', 's', 0, 1, pw, ph,
+    description='Average PipelineRun wall-clock duration per version per day. Lower is better.'),
+  versionBar('PipelineRun Succeeded', '__results_PipelineRuns_count_succeeded', 'short', 0, 9, pw, ph,
+    description='Total successful PipelineRuns per version per day.', agg='SUM'),
+  versionBar('PipelineRun Failed', '__results_PipelineRuns_count_failed', 'short', 0, 17, pw, ph,
+    description='Total failed PipelineRuns per version per day. Should be 0.', agg='SUM', axisSoftMax=5),
+  versionBar('PR Pending Time (avg)', '__results_PipelineRuns_Success_pending_avg', 's', 0, 25, pw, ph,
+    description='Average time a successful PipelineRun waited to be scheduled.'),
+  versionBar('PR Running Time (avg)', '__results_PipelineRuns_Success_running_avg', 's', 0, 33, pw, ph,
+    description='Average time a successful PipelineRun spent executing.'),
+
+  row('TaskRun Performance', 41),
+  versionBar('TaskRun Duration (avg)', '__results_TaskRuns_duration_avg', 's', 0, 42, pw, ph,
+    description='Average successful TaskRun duration per version per day. Lower is better.'),
+  versionBar('TaskRun Succeeded', '__results_TaskRuns_count_succeeded', 'short', 0, 50, pw, ph,
+    description='Total successful TaskRuns per version per day.', agg='SUM'),
+  versionBar('TaskRun Failed', '__results_TaskRuns_count_failed', 'short', 0, 58, pw, ph,
+    description='Total failed TaskRuns per version per day. Should be 0.', agg='SUM', axisSoftMax=5),
+  versionBar('TR Pending Time (avg)', '__results_TaskRuns_Success_pending_avg', 's', 0, 66, pw, ph,
+    description='Average Pod scheduling wait for successful TaskRuns.'),
+  versionBar('TR Running Time (avg)', '__results_TaskRuns_Success_running_avg', 's', 0, 74, pw, ph,
+    description='Average container execution time for successful TaskRuns.'),
+
+  row('Controller Health', 82),
+  versionBar('TaskRun → Pod Creation Lag', '__results_TaskRunsToPods_creationTimestampDiff_mean', 's', 0, 83, pw, ph,
+    description='Mean time from TaskRun creation to Pod creation.'),
+  versionBar('Controller CPU', '__measurements_tektonPipelinesController_cpu_mean', 'short', 0, 91, pw, ph,
+    description='Tekton Pipelines controller mean CPU (cores).'),
+  versionBar('Controller Memory', '__measurements_tektonPipelinesController_memory_mean', 'bytes', 0, 99, pw, ph,
+    description='Tekton Pipelines controller mean memory (RSS).'),
+  versionBar('Workqueue Depth', '__measurements_tektonTektonPipelinesControllerWorkqueueDepth_mean', 'short', 0, 107, pw, ph,
+    description='Controller workqueue depth. High = bottleneck.'),
+  versionBar('Webhook CPU', '__measurements_tektonPipelinesWebhook_cpu_mean', 'short', 0, 115, pw, ph,
+    description='Admission webhook CPU.'),
+  versionBar('Webhook Memory', '__measurements_tektonPipelinesWebhook_memory_mean', 'bytes', 0, 123, pw, ph,
+    description='Admission webhook memory.'),
+  versionBar('Controller Client Latency', '__measurements_tektonPipelinesControllerClientLatencyAverage_mean', 's', 0, 131, pw, ph,
+    description='Controller → API server HTTP latency.'),
+
+  row('Cluster & Infrastructure', 139),
+  versionBar('Cluster CPU', '__measurements_clusterCpuUsageSecondsTotalRate_mean', 'short', 0, 140, pw, ph,
+    description='Mean total cluster CPU usage rate (cores).'),
+  versionBar('Cluster Memory', '__measurements_clusterMemoryUsageRssTotal_mean', 'bytes', 0, 148, pw, ph,
+    description='Mean total cluster RSS memory.'),
+  versionBar('API Server CPU', '__measurements_apiserver_cpu_mean', 'short', 0, 156, pw, ph,
+    description='OpenShift API server mean CPU.'),
+  versionBar('Kube API Server CPU', '__measurements_kubeApiserver_cpu_mean', 'short', 0, 164, pw, ph,
+    description='Kubernetes API server mean CPU.'),
+  versionBar('API Server Memory', '__measurements_apiserver_memory_mean', 'bytes', 0, 172, pw, ph,
+    description='OpenShift API server mean memory.'),
+
+  row('etcd', 180),
+  versionBar('etcd DB Size', '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean', 'bytes', 0, 181, pw, ph,
+    description='Mean etcd MVCC database total size.'),
+  versionBar('etcd DB In Use', '__measurements_etcdMvccDbTotalSizeInUseInBytesAverage_mean', 'bytes', 0, 189, pw, ph,
+    description='Mean etcd live data size.'),
+  versionBar('etcd Request Duration', '__measurements_etcdRequestDurationSecondsAverage_mean', 's', 0, 197, pw, ph,
+    description='Mean etcd request latency.'),
+  versionBar('etcd Restarts', '__measurements_etcd_restarts_range', 'short', 0, 205, pw, ph,
+    description='etcd Pod restarts. Should be 0.', agg='SUM', axisSoftMax=5),
+  versionBar('Scheduler Pending Pods', '__measurements_schedulerPendingPodsCount_range', 'short', 0, 213, pw, ph,
+    description='Pending pods in kube-scheduler queue.', agg='SUM', axisSoftMax=5),
+];
+
+dashboard.new('Pipelines Version Comparison (v2)')
++ dashboard.withUid('Pipelines_Version_Comparison_v2')
++ dashboard.withDescription('Daily side-by-side version comparison of OpenShift Pipelines performance.')
++ dashboard.time.withFrom('now-14d')
++ dashboard.time.withTo('now')
++ dashboard.withTimezone('utc')
++ dashboard.withRefresh('5m')
++ dashboard.withVariables([datasourceVar, variantVar, versionVar, concurrencyVar])
++ dashboard.withPanels(allPanels)
++ dashboard.withEditable(true)
++ dashboard.withTags(['pipelines', 'version-comparison', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()

--- a/config/grafonnet-workdir/src/results-comparison-dashboard.jsonnet
+++ b/config/grafonnet-workdir/src/results-comparison-dashboard.jsonnet
@@ -1,0 +1,195 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/results-common.libsonnet';
+
+local dashboard = grafonnet.dashboard;
+local timeSeries = grafonnet.panel.timeSeries;
+
+local testId = common.testId;
+local versionExpr = common.versionExpr;
+local datasourceVar = common.datasourceVar;
+
+local versionQuery = "SELECT DISTINCT %s AS version FROM data WHERE horreum_testid = %g AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testId];
+
+local createVersionVar(name, label, defaultVersion) = {
+  type: 'query',
+  name: name,
+  label: label,
+  description: '%s for comparison.' % label,
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: versionQuery,
+  multi: false,
+  includeAll: false,
+  current: { text: defaultVersion, value: defaultVersion },
+  refresh: 2,
+  sort: 0,
+};
+
+local version1Var = createVersionVar('version1', 'Version 1', 'nightly');
+local version2Var = createVersionVar('version2', 'Version 2', '1.22');
+
+local versionPredicate(varName) = |||
+        AND %s = '${%s}'
+||| % [versionExpr, varName];
+
+local createQuery(fieldName, metricLabel, versionVar, additionalFields={}) =
+  local baseFields = { [metricLabel]: fieldName };
+  local allFields = baseFields + additionalFields;
+  local fieldSelections = std.join(',\n    ', [
+    "AVG((label_values->>'%s')::DOUBLE PRECISION) AS %s" % [allFields[key], key]
+    for key in std.objectFields(allFields)
+  ]);
+  local fieldConditions = std.join('\n    AND ', [
+    "label_values ? '%s'" % allFields[key]
+    for key in std.objectFields(allFields)
+  ]);
+  local selectStatements = std.join('\n\nUNION ALL\n\n', [
+    |||
+      SELECT
+        EXTRACT(EPOCH FROM day) AS time,
+        '%s' AS metric,
+        %s AS value
+      FROM daily_agg
+    ||| % [key, key]
+    for key in std.objectFields(allFields)
+  ]);
+
+  {
+    rawSql: |||
+      WITH daily_agg AS (
+        SELECT
+          DATE_TRUNC('day', start) AS day,
+          %s
+        FROM data
+        WHERE horreum_testid = %g
+          AND $__timeFilter(start)
+          %s
+          AND %s
+        GROUP BY day
+      )
+
+      %s
+
+      ORDER BY time, metric;
+    ||| % [fieldSelections, testId, versionPredicate(versionVar), fieldConditions, selectStatements],
+    format: 'time_series',
+    refId: 'A',
+  };
+
+local compPanel(title, fieldName, metricLabel, unit, gridX, gridY, gridW=12, gridH=8, versionVar='version1', additionalFields={}, description='') =
+  timeSeries.new('%s — ${%s}' % [title, versionVar])
+  + timeSeries.queryOptions.withDatasource(type='grafana-postgresql-datasource', uid='${datasource}')
+  + (if description != '' then timeSeries.panelOptions.withDescription(description) else {})
+  + timeSeries.gridPos.withX(gridX)
+  + timeSeries.gridPos.withY(gridY)
+  + timeSeries.gridPos.withW(gridW)
+  + timeSeries.gridPos.withH(gridH)
+  + timeSeries.fieldConfig.defaults.custom.withDrawStyle('line')
+  + timeSeries.fieldConfig.defaults.custom.withLineWidth(2)
+  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(8)
+  + timeSeries.fieldConfig.defaults.custom.withGradientMode('opacity')
+  + timeSeries.fieldConfig.defaults.custom.withSpanNulls(false)
+  + timeSeries.fieldConfig.defaults.custom.withShowPoints('always')
+  + timeSeries.fieldConfig.defaults.custom.withPointSize(6)
+  + timeSeries.standardOptions.withUnit(unit)
+  + timeSeries.standardOptions.withMin(0)
+  + timeSeries.options.withTooltip({ mode: 'multi', sort: 'desc' })
+  + timeSeries.options.withLegend({ displayMode: 'list', placement: 'bottom', calcs: [] })
+  + timeSeries.queryOptions.withTargets([
+    createQuery(fieldName, metricLabel, versionVar, additionalFields),
+  ]);
+
+local sideBySide(title, fieldName, metricLabel, unit, y, additionalFields={}, description='') = [
+  compPanel(title, fieldName, metricLabel, unit, 0, y, 12, 8, 'version1', additionalFields, description),
+  compPanel(title, fieldName, metricLabel, unit, 12, y, 12, 8, 'version2', additionalFields, description),
+];
+
+local row(title, y) = {
+  type: 'row',
+  title: title,
+  gridPos: { h: 1, w: 24, x: 0, y: y },
+};
+
+local allPanels = [
+  // ── PipelineRun Ingestion ──────────────────────────────────────
+  row('PipelineRun Ingestion', 0),
+] + sideBySide('PR Ingestion Throughput', '__results_PipelineRuns_ingestion_throughput', 'throughput', 'short', 1,
+    description='Rate at which the Results watcher ingests completed PipelineRuns (records/sec). Higher indicates faster ingestion.')
++ sideBySide('PR Ingestion Duration', '__results_PipelineRuns_ingestion_duration', 'duration', 's', 9,
+    description='Total wall-clock time for the Results watcher to ingest all completed PipelineRuns. Lower means the watcher kept up with the pipeline creation rate.')
++ sideBySide('PR Stored Successfully', '__results_PipelineRuns_ingestion_count_stored_true', 'stored_ok', 'short', 17,
+    description='Number of PipelineRun records successfully persisted to the Results API database.')
++ sideBySide('PR Store Failures', '__results_PipelineRuns_ingestion_count_stored_false', 'stored_fail', 'short', 25,
+    description='Number of PipelineRun records that failed to persist. Non-zero indicates API errors, DB write failures, or resource exhaustion.')
++ [
+  // ── TaskRun Ingestion ──────────────────────────────────────────
+  row('TaskRun Ingestion', 33),
+] + sideBySide('TR Ingestion Throughput', '__results_TaskRuns_ingestion_throughput', 'throughput', 'short', 34,
+    description='Rate at which the Results watcher ingests completed TaskRuns (records/sec). Each PipelineRun contains 5 tasks × 10 steps.')
++ sideBySide('TR Ingestion Duration', '__results_TaskRuns_ingestion_duration', 'duration', 's', 42,
+    description='Total wall-clock time for the Results watcher to ingest all completed TaskRuns.')
++ sideBySide('TR Stored Successfully', '__results_TaskRuns_ingestion_count_stored_true', 'stored_ok', 'short', 50,
+    description='Number of TaskRun records successfully persisted to the Results API database.')
++ sideBySide('TR Store Failures', '__results_TaskRuns_ingestion_count_stored_false', 'stored_fail', 'short', 58,
+    description='Number of TaskRun records that failed to persist. Non-zero indicates API errors, DB write failures, or resource exhaustion.')
++ [
+  // ── Results API ────────────────────────────────────────────────
+  row('Results API', 66),
+] + sideBySide('/record Latency', '__results_ResultsAPI_record_latency_avg', 'latency_avg', 'ms', 67,
+    { latency_max: '__results_ResultsAPI_record_latency_max' },
+    description='Latency of the Results API /record endpoint under Locust load test (100 users, 10 spawn/sec, 15 min). Shows mean and worst-case response time.')
++ sideBySide('/record RPS', '__results_ResultsAPI_record_rps', 'rps', 'reqps', 75,
+    description='Sustained requests per second to the Results API /record endpoint during Locust load test. Measures single-record fetch throughput.')
++ sideBySide('/records Latency', '__results_ResultsAPI_records_latency_avg', 'latency_avg', 'ms', 83,
+    { latency_max: '__results_ResultsAPI_records_latency_max' },
+    description='Latency of the Results API /records (list) endpoint under Locust load test. Typically higher than /record due to pagination and result set construction.')
++ sideBySide('/records RPS', '__results_ResultsAPI_records_rps', 'rps', 'reqps', 91,
+    description='Sustained requests per second to the Results API /records (list) endpoint during Locust load test. Measures bulk-fetch throughput.')
++ [
+  // ── Results Component Metrics ──────────────────────────────────
+  row('Results Watcher & API Server', 99),
+] + sideBySide('Watcher CPU', '__measurements_tektonResultsWatcher_cpu_mean', 'cpu_mean', 'short', 100,
+    { cpu_max: '__measurements_tektonResultsWatcher_cpu_max' },
+    description='CPU of the tekton-results-watcher Pod (cores). Watches for completed PipelineRuns/TaskRuns and persists them to the Results API.')
++ sideBySide('Watcher Memory', '__measurements_tektonResultsWatcher_memory_mean', 'mem_mean', 'bytes', 108,
+    { mem_max: '__measurements_tektonResultsWatcher_memory_max' },
+    description='Memory (RSS) of the tekton-results-watcher Pod. High memory may indicate large watch caches or slow GC under high ingestion load.')
++ sideBySide('API Server CPU', '__measurements_tektonResultsApi_cpu_mean', 'cpu_mean', 'short', 116,
+    { cpu_max: '__measurements_tektonResultsApi_cpu_max' },
+    description='CPU of the tekton-results-api Pod (cores). Serves the Results REST API hit by the Locust load test.')
++ sideBySide('API Server Memory', '__measurements_tektonResultsApi_memory_mean', 'mem_mean', 'bytes', 124,
+    { mem_max: '__measurements_tektonResultsApi_memory_max' },
+    description='Memory (RSS) of the tekton-results-api Pod. High memory may indicate query result caching or connection pool growth under Locust load.')
++ [
+  // ── Pipeline Performance ───────────────────────────────────────
+  row('Pipeline Performance', 132),
+] + sideBySide('PipelineRun Duration (avg)', '__results_PipelineRuns_duration_avg', 'pr_duration', 's', 133,
+    description='Average wall-clock time from PipelineRun creation to completion. Each pipeline has 5 tasks × 10 steps × 15 log lines. Includes scheduling, execution, and signing overhead.')
++ sideBySide('PipelineRun Succeeded', '__results_PipelineRuns_count_succeeded', 'pr_succeeded', 'short', 141,
+    description='Total PipelineRuns that completed successfully. The test creates PRs at a constant rate with 30 concurrent; all should succeed.')
++ [
+  // ── Cluster & Infrastructure ───────────────────────────────────
+  row('Cluster & Infrastructure', 149),
+] + sideBySide('Cluster CPU', '__measurements_clusterCpuUsageSecondsTotalRate_mean', 'cluster_cpu', 'short', 150,
+    description='Mean total cluster CPU usage rate (cores) across all nodes. Reflects the combined load of pipeline execution, signing, ingestion, and Locust testing.')
++ sideBySide('Cluster Memory', '__measurements_clusterMemoryUsageRssTotal_mean', 'cluster_mem', 'bytes', 158,
+    description='Mean total cluster RSS memory across all nodes during the test.')
++ [
+  // ── etcd ───────────────────────────────────────────────────────
+  row('etcd', 166),
+] + sideBySide('etcd DB Size', '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean', 'db_total', 'bytes', 167,
+    description='Mean etcd MVCC database total size. Reflects Kubernetes object storage growth from PipelineRun/TaskRun creation.')
++ sideBySide('etcd Request Duration', '__measurements_etcdRequestDurationSecondsAverage_mean', 'req_duration', 's', 175,
+    description='Mean etcd request latency. High latency indicates etcd is under pressure from the volume of Kubernetes API operations.');
+
+dashboard.new('Results Comparison Dashboard')
++ dashboard.withUid('Results_Comparison')
++ dashboard.withDescription('Side-by-side comparison of two Tekton Results versions. Test ID 425.')
++ dashboard.time.withFrom('now-30d')
++ dashboard.time.withTo('now')
++ dashboard.withTimezone('utc')
++ dashboard.withRefresh('5m')
++ dashboard.withVariables([datasourceVar, version1Var, version2Var])
++ dashboard.withPanels(allPanels)
++ dashboard.withEditable(true)
++ dashboard.withTags(['results', 'comparison', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()

--- a/config/grafonnet-workdir/src/results-dashboard.jsonnet
+++ b/config/grafonnet-workdir/src/results-dashboard.jsonnet
@@ -1,0 +1,304 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/results-common.libsonnet';
+
+local dashboard = grafonnet.dashboard;
+local timeSeries = grafonnet.panel.timeSeries;
+
+local testId = common.testId;
+local versionExpr = common.versionExpr;
+local datasourceVar = common.datasourceVar;
+
+local versionVar = {
+  type: 'query',
+  name: 'version',
+  label: 'Version',
+  description: 'Filter by deployment version.',
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: "SELECT DISTINCT %s AS version FROM data WHERE horreum_testid = %g AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testId],
+  multi: false,
+  includeAll: false,
+  current: { text: 'nightly', value: 'nightly' },
+  refresh: 2,
+  sort: 0,
+};
+
+local concurrencyVar = {
+  type: 'query',
+  name: 'concurrency',
+  label: 'Concurrency',
+  description: 'Filter by concurrency level.',
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: "SELECT DISTINCT (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency FROM data WHERE horreum_testid = %g AND $__timeFilter(start) AND label_values ? '__parameters_test_concurrent' ORDER BY concurrency" % testId,
+  multi: true,
+  includeAll: true,
+  current: { text: 'All', value: '$__all' },
+  refresh: 2,
+  sort: 3,
+};
+
+local concurrencyPredicate = |||
+        AND (label_values->>'__parameters_test_concurrent')::INTEGER IN ($concurrency)
+|||;
+
+local createQuery(fieldName, metricLabel, additionalFields={}) =
+  local baseFields = { [metricLabel]: fieldName };
+  local allFields = baseFields + additionalFields;
+  local fieldSelections = std.join(',\n    ', [
+    "AVG((label_values->>'%s')::DOUBLE PRECISION) AS %s" % [allFields[key], key]
+    for key in std.objectFields(allFields)
+  ]);
+  local fieldConditions = std.join('\n    AND ', [
+    "label_values ? '%s'" % allFields[key]
+    for key in std.objectFields(allFields)
+  ]);
+  local selectStatements = std.join('\n\nUNION ALL\n\n', [
+    |||
+      SELECT
+        EXTRACT(EPOCH FROM day) AS time,
+        '%s @ ' || version || ' / c' || concurrency AS metric,
+        %s AS value
+      FROM daily_agg
+    ||| % [key, key]
+    for key in std.objectFields(allFields)
+  ]);
+
+  {
+    rawSql: |||
+      WITH daily_agg AS (
+        SELECT
+          DATE_TRUNC('day', start) AS day,
+          %s AS version,
+          (label_values->>'__parameters_test_concurrent')::INTEGER AS concurrency,
+          %s
+        FROM data
+        WHERE horreum_testid = %g
+          AND $__timeFilter(start)
+          AND %s = '${version}'
+          %s
+          AND %s
+        GROUP BY day, version, concurrency
+      )
+
+      %s
+
+      ORDER BY time, metric;
+    ||| % [versionExpr, fieldSelections, testId, versionExpr, concurrencyPredicate, fieldConditions, selectStatements],
+    format: 'time_series',
+    refId: 'A',
+  };
+
+local createPanel(title, fieldName, metricLabel, unit='short', gridX=0, gridY=0, gridW=12, gridH=8, additionalFields={}, description='', axisSoftMax=null) =
+  timeSeries.new(title)
+  + timeSeries.queryOptions.withDatasource(type='grafana-postgresql-datasource', uid='${datasource}')
+  + (if description != '' then timeSeries.panelOptions.withDescription(description) else {})
+  + timeSeries.gridPos.withX(gridX)
+  + timeSeries.gridPos.withY(gridY)
+  + timeSeries.gridPos.withW(gridW)
+  + timeSeries.gridPos.withH(gridH)
+  + timeSeries.fieldConfig.defaults.custom.withDrawStyle('line')
+  + timeSeries.fieldConfig.defaults.custom.withLineWidth(2)
+  + timeSeries.fieldConfig.defaults.custom.withFillOpacity(8)
+  + timeSeries.fieldConfig.defaults.custom.withGradientMode('opacity')
+  + timeSeries.fieldConfig.defaults.custom.withSpanNulls(false)
+  + timeSeries.fieldConfig.defaults.custom.withShowPoints('always')
+  + timeSeries.fieldConfig.defaults.custom.withPointSize(6)
+  + timeSeries.standardOptions.withUnit(unit)
+  + timeSeries.standardOptions.withMin(0)
+  + timeSeries.options.withTooltip({ mode: 'multi', sort: 'desc' })
+  + timeSeries.options.withLegend({ displayMode: 'list', placement: 'bottom', calcs: [] })
+  + (if axisSoftMax != null then { fieldConfig+: { defaults+: { custom+: { axisSoftMax: axisSoftMax } } } } else {})
+  + timeSeries.queryOptions.withTargets([
+    createQuery(fieldName, metricLabel, additionalFields),
+  ]);
+
+local row(title, y) = {
+  type: 'row',
+  title: title,
+  gridPos: { h: 1, w: 24, x: 0, y: y },
+};
+
+local allPanels = [
+  // ── PipelineRun Ingestion ──────────────────────────────────────
+  row('PipelineRun Ingestion', 0),
+  createPanel(
+    'PR Ingestion Throughput',
+    '__results_PipelineRuns_ingestion_throughput', 'throughput', 'short',
+    0, 1, 12, 8,
+    description='Rate at which the Results watcher ingests completed PipelineRuns into the Results API (records/sec). Higher indicates faster ingestion. Measured during the signing+ingestion phase of the test.'
+  ),
+  createPanel(
+    'PR Ingestion Duration',
+    '__results_PipelineRuns_ingestion_duration', 'duration', 's',
+    12, 1, 12, 8,
+    description='Total wall-clock time for the Results watcher to ingest all completed PipelineRuns. Lower means the watcher kept up with the pipeline creation rate.'
+  ),
+  createPanel(
+    'PR Stored Successfully',
+    '__results_PipelineRuns_ingestion_count_stored_true', 'stored_ok', 'short',
+    0, 9, 12, 8,
+    description='Number of PipelineRun records the Results watcher successfully persisted to the Results API database.'
+  ),
+  createPanel(
+    'PR Store Failures',
+    '__results_PipelineRuns_ingestion_count_stored_false', 'stored_fail', 'short',
+    12, 9, 12, 8,
+    description='Number of PipelineRun records the Results watcher failed to persist. Non-zero values indicate API errors, DB write failures, or resource exhaustion.'
+  ),
+
+  // ── TaskRun Ingestion ──────────────────────────────────────────
+  row('TaskRun Ingestion', 17),
+  createPanel(
+    'TR Ingestion Throughput',
+    '__results_TaskRuns_ingestion_throughput', 'throughput', 'short',
+    0, 18, 12, 8,
+    description='Rate at which the Results watcher ingests completed TaskRuns into the Results API (records/sec). Each PipelineRun contains multiple TaskRuns (5 tasks × steps).'
+  ),
+  createPanel(
+    'TR Ingestion Duration',
+    '__results_TaskRuns_ingestion_duration', 'duration', 's',
+    12, 18, 12, 8,
+    description='Total wall-clock time for the Results watcher to ingest all completed TaskRuns.'
+  ),
+  createPanel(
+    'TR Stored Successfully',
+    '__results_TaskRuns_ingestion_count_stored_true', 'stored_ok', 'short',
+    0, 26, 12, 8,
+    description='Number of TaskRun records the Results watcher successfully persisted to the Results API database.'
+  ),
+  createPanel(
+    'TR Store Failures',
+    '__results_TaskRuns_ingestion_count_stored_false', 'stored_fail', 'short',
+    12, 26, 12, 8,
+    description='Number of TaskRun records the Results watcher failed to persist. Non-zero values indicate API errors, DB write failures, or resource exhaustion.'
+  ),
+
+  // ── Results API ─────────────────────────────────────────────────
+  row('Results API', 34),
+  createPanel(
+    '/record Latency',
+    '__results_ResultsAPI_record_latency_avg', 'latency_avg', 'ms',
+    0, 35, 12, 8,
+    { latency_max: '__results_ResultsAPI_record_latency_max' },
+    description='Latency of the Results API /record endpoint under Locust load test (100 users, 10 spawn/sec, 15 min).\n- **latency_avg**: mean response time\n- **latency_max**: worst-case response time'
+  ),
+  createPanel(
+    '/record RPS',
+    '__results_ResultsAPI_record_rps', 'rps', 'reqps',
+    12, 35, 12, 8,
+    description='Sustained requests per second to the Results API /record endpoint during the Locust load test. Measures single-record fetch throughput.'
+  ),
+  createPanel(
+    '/records Latency',
+    '__results_ResultsAPI_records_latency_avg', 'latency_avg', 'ms',
+    0, 43, 12, 8,
+    { latency_max: '__results_ResultsAPI_records_latency_max' },
+    description='Latency of the Results API /records (list) endpoint under Locust load test.\n- **latency_avg**: mean response time\n- **latency_max**: worst-case response time'
+  ),
+  createPanel(
+    '/records RPS',
+    '__results_ResultsAPI_records_rps', 'rps', 'reqps',
+    12, 43, 12, 8,
+    description='Sustained requests per second to the Results API /records (list) endpoint during the Locust load test. Measures bulk-fetch throughput.'
+  ),
+
+  // ── Results Component Metrics ──────────────────────────────────
+  row('Results Watcher & API Server', 51),
+  createPanel(
+    'Watcher CPU',
+    '__measurements_tektonResultsWatcher_cpu_mean', 'cpu_mean', 'short',
+    0, 52, 12, 8,
+    { cpu_max: '__measurements_tektonResultsWatcher_cpu_max' },
+    description='CPU usage of the tekton-results-watcher Pod (cores). The watcher watches for completed PipelineRuns/TaskRuns and persists them to the Results API.\n- **cpu_mean**: average over test duration\n- **cpu_max**: peak usage'
+  ),
+  createPanel(
+    'Watcher Memory',
+    '__measurements_tektonResultsWatcher_memory_mean', 'mem_mean', 'bytes',
+    12, 52, 12, 8,
+    { mem_max: '__measurements_tektonResultsWatcher_memory_max' },
+    description='Memory (RSS) of the tekton-results-watcher Pod. High memory may indicate large watch caches or slow GC under high ingestion load.\n- **mem_mean**: average over test duration\n- **mem_max**: peak usage'
+  ),
+  createPanel(
+    'API Server CPU',
+    '__measurements_tektonResultsApi_cpu_mean', 'cpu_mean', 'short',
+    0, 60, 12, 8,
+    { cpu_max: '__measurements_tektonResultsApi_cpu_max' },
+    description='CPU usage of the tekton-results-api Pod (cores). Serves the Results REST API hit by the Locust load test (/record, /records endpoints).\n- **cpu_mean**: average over test duration\n- **cpu_max**: peak usage'
+  ),
+  createPanel(
+    'API Server Memory',
+    '__measurements_tektonResultsApi_memory_mean', 'mem_mean', 'bytes',
+    12, 60, 12, 8,
+    { mem_max: '__measurements_tektonResultsApi_memory_max' },
+    description='Memory (RSS) of the tekton-results-api Pod. High memory may indicate query result caching or connection pool growth under Locust load.\n- **mem_mean**: average over test duration\n- **mem_max**: peak usage'
+  ),
+
+  // ── Pipeline Performance ───────────────────────────────────────
+  row('Pipeline Performance', 68),
+  createPanel(
+    'PipelineRun Duration (avg)',
+    '__results_PipelineRuns_duration_avg', 'pr_duration', 's',
+    0, 69, 12, 8,
+    description='Average wall-clock time from PipelineRun creation to completion. Each pipeline has 5 tasks × 10 steps × 15 log lines. Includes scheduling, execution, and signing overhead.'
+  ),
+  createPanel(
+    'PipelineRun Succeeded',
+    '__results_PipelineRuns_count_succeeded', 'pr_succeeded', 'short',
+    12, 69, 12, 8,
+    description='Total PipelineRuns that completed successfully. The test creates PRs at a constant rate with 30 concurrent; all should succeed.'
+  ),
+
+  // ── Cluster & Infrastructure ───────────────────────────────────
+  row('Cluster & Infrastructure', 85),
+  createPanel(
+    'Cluster CPU',
+    '__measurements_clusterCpuUsageSecondsTotalRate_mean', 'cluster_cpu', 'short',
+    0, 86, 12, 8,
+    description='Mean total cluster CPU usage rate (cores) across all nodes during the test. Reflects the combined load of pipelines execution, signing, ingestion, and Locust testing.'
+  ),
+  createPanel(
+    'Cluster Memory',
+    '__measurements_clusterMemoryUsageRssTotal_mean', 'cluster_mem', 'bytes',
+    12, 86, 12, 8,
+    description='Mean total cluster RSS memory across all nodes during the test.'
+  ),
+  createPanel(
+    'Pipelines Controller CPU',
+    '__measurements_tektonPipelinesController_cpu_mean', 'ctrl_cpu', 'short',
+    0, 94, 12, 8,
+    description='Mean CPU of the Tekton Pipelines controller. Handles PipelineRun/TaskRun reconciliation. Higher values indicate more reconciliation overhead.'
+  ),
+  createPanel(
+    'Pipelines Controller Memory',
+    '__measurements_tektonPipelinesController_memory_mean', 'ctrl_mem', 'bytes',
+    12, 94, 12, 8,
+    description='Mean memory (RSS) of the Tekton Pipelines controller. Growth may indicate large informer caches from many concurrent PipelineRuns.'
+  ),
+
+  // ── etcd ───────────────────────────────────────────────────────
+  row('etcd', 102),
+  createPanel(
+    'etcd DB Size',
+    '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean', 'db_total', 'bytes',
+    0, 103, 12, 8,
+    description='Mean etcd MVCC database total size. Reflects the cumulative Kubernetes object storage. Rapid growth during the test indicates high PipelineRun/TaskRun creation rate.'
+  ),
+  createPanel(
+    'etcd Request Duration',
+    '__measurements_etcdRequestDurationSecondsAverage_mean', 'req_duration', 's',
+    12, 103, 12, 8,
+    description='Mean etcd request latency. High latency indicates etcd is under pressure from the volume of Kubernetes API operations (PR/TR CRUD + status updates).'
+  ),
+];
+
+dashboard.new('Results Performance Dashboard')
++ dashboard.withUid('Results_Performance')
++ dashboard.withDescription('Tekton Results performance — watcher ingestion latency, API load testing, and component resource usage across versions. Test ID 425.')
++ dashboard.time.withFrom('now-30d')
++ dashboard.time.withTo('now')
++ dashboard.withTimezone('utc')
++ dashboard.withRefresh('5m')
++ dashboard.withVariables([datasourceVar, versionVar, concurrencyVar])
++ dashboard.withPanels(allPanels)
++ dashboard.withEditable(true)
++ dashboard.withTags(['results', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()

--- a/config/grafonnet-workdir/src/results-version-comparison-v2.jsonnet
+++ b/config/grafonnet-workdir/src/results-version-comparison-v2.jsonnet
@@ -1,0 +1,137 @@
+local grafonnet = import 'github.com/grafana/grafonnet/gen/grafonnet-latest/main.libsonnet';
+local common = import 'lib/results-common.libsonnet';
+local versionBarLib = import 'lib/version-bar-common.libsonnet';
+
+local dashboard = grafonnet.dashboard;
+
+local testId = common.testId;
+local versionExpr = common.versionExpr;
+local datasourceVar = common.datasourceVar;
+
+local versionVar = {
+  type: 'query',
+  name: 'version',
+  label: 'Version',
+  description: 'Select versions to compare. Use All to include every version.',
+  datasource: { type: 'grafana-postgresql-datasource', uid: '${datasource}' },
+  query: "SELECT DISTINCT %s AS version FROM data WHERE horreum_testid = %g AND $__timeFilter(start) AND label_values ? '__deployment_version' ORDER BY version DESC" % [versionExpr, testId],
+  multi: true,
+  includeAll: true,
+  current: { text: 'All', value: '$__all' },
+  refresh: 2,
+  sort: 0,
+};
+
+local createQuery(fieldName, agg='AVG') =
+  {
+    rawSql: |||
+      WITH daily AS (
+        SELECT
+          TO_CHAR(DATE_TRUNC('day', start), 'MM/DD') AS day,
+          DATE_TRUNC('day', start) AS day_date,
+          %s AS version,
+          (label_values->>'%s')::DOUBLE PRECISION AS val
+        FROM data
+        WHERE horreum_testid = %g
+          AND $__timeFilter(start)
+          AND %s IN ($version)
+          AND label_values ? '%s'
+      )
+      SELECT day, version, %s(val) AS value
+      FROM daily
+      GROUP BY day, version
+      ORDER BY MIN(day_date),
+        CASE WHEN version = 'nightly' THEN 0 ELSE 1 END,
+        version ASC
+    ||| % [versionExpr, fieldName, testId, versionExpr, fieldName, agg],
+    format: 'table',
+    refId: 'A',
+  };
+
+local row = versionBarLib.row;
+
+local versionBar(title, fieldName, unit, x, y, w, h, description='', agg='AVG', axisSoftMax=null) =
+  versionBarLib.versionBar(createQuery, title, fieldName, unit, x, y, w, h, description, agg, axisSoftMax);
+
+local pw = 24;
+local ph = 8;
+
+local allPanels = [
+  // ── PipelineRun Ingestion ──────────────────────────────────────
+  row('PipelineRun Ingestion', 0),
+  versionBar('PR Ingestion Throughput', '__results_PipelineRuns_ingestion_throughput', 'short', 0, 1, pw, ph,
+    description='Rate at which the Results watcher ingests completed PipelineRuns (records/sec). Higher indicates faster ingestion. Compare across versions to detect watcher performance regressions.'),
+  versionBar('PR Ingestion Duration', '__results_PipelineRuns_ingestion_duration', 's', 0, 9, pw, ph,
+    description='Total wall-clock time for the Results watcher to ingest all completed PipelineRuns. Lower means the watcher kept up with the pipeline creation rate.'),
+  versionBar('PR Stored Successfully', '__results_PipelineRuns_ingestion_count_stored_true', 'none', 0, 17, pw, ph,
+    description='Number of PipelineRun records successfully persisted to the Results API database per version per day.', agg='SUM'),
+  versionBar('PR Store Failures', '__results_PipelineRuns_ingestion_count_stored_false', 'none', 0, 25, pw, ph,
+    description='Number of PipelineRun records that failed to persist. Non-zero values indicate API errors, DB write failures, or resource exhaustion.', agg='SUM'),
+
+  // ── TaskRun Ingestion ──────────────────────────────────────────
+  row('TaskRun Ingestion', 33),
+  versionBar('TR Ingestion Throughput', '__results_TaskRuns_ingestion_throughput', 'short', 0, 34, pw, ph,
+    description='Rate at which the Results watcher ingests completed TaskRuns (records/sec). Each PipelineRun contains 5 tasks × 10 steps.'),
+  versionBar('TR Ingestion Duration', '__results_TaskRuns_ingestion_duration', 's', 0, 42, pw, ph,
+    description='Total wall-clock time for the Results watcher to ingest all completed TaskRuns.'),
+  versionBar('TR Stored Successfully', '__results_TaskRuns_ingestion_count_stored_true', 'none', 0, 50, pw, ph,
+    description='Number of TaskRun records successfully persisted to the Results API database per version per day.', agg='SUM'),
+  versionBar('TR Store Failures', '__results_TaskRuns_ingestion_count_stored_false', 'none', 0, 58, pw, ph,
+    description='Number of TaskRun records that failed to persist. Non-zero values indicate API errors, DB write failures, or resource exhaustion.', agg='SUM'),
+
+  // ── Results API ────────────────────────────────────────────────
+  row('Results API', 66),
+  versionBar('/record Latency (avg)', '__results_ResultsAPI_record_latency_avg', 'ms', 0, 67, pw, ph,
+    description='Average response time of the Results API /record endpoint under Locust load test (100 users, 10 spawn/sec, 15 min). Measures single-record fetch latency.'),
+  versionBar('/record RPS', '__results_ResultsAPI_record_rps', 'reqps', 0, 75, pw, ph,
+    description='Sustained requests per second to the Results API /record endpoint during Locust load test. Higher is better — indicates the API can handle more concurrent fetch requests.'),
+  versionBar('/records Latency (avg)', '__results_ResultsAPI_records_latency_avg', 'ms', 0, 83, pw, ph,
+    description='Average response time of the Results API /records (list) endpoint under Locust load test. Typically higher than /record due to pagination and result set construction.'),
+  versionBar('/records RPS', '__results_ResultsAPI_records_rps', 'reqps', 0, 91, pw, ph,
+    description='Sustained requests per second to the Results API /records (list) endpoint during Locust load test. Measures bulk-fetch throughput.'),
+
+  // ── Results Component Metrics ──────────────────────────────────
+  row('Results Watcher & API Server', 99),
+  versionBar('Watcher CPU (mean)', '__measurements_tektonResultsWatcher_cpu_mean', 'short', 0, 100, pw, ph,
+    description='Mean CPU of the tekton-results-watcher Pod (cores). The watcher watches for completed PipelineRuns/TaskRuns and persists them to the Results API.'),
+  versionBar('Watcher Memory (mean)', '__measurements_tektonResultsWatcher_memory_mean', 'bytes', 0, 108, pw, ph,
+    description='Mean memory (RSS) of the tekton-results-watcher Pod. High memory may indicate large watch caches or slow GC under high ingestion load.'),
+  versionBar('API Server CPU (mean)', '__measurements_tektonResultsApi_cpu_mean', 'short', 0, 116, pw, ph,
+    description='Mean CPU of the tekton-results-api Pod (cores). Serves the Results REST API hit by the Locust load test.'),
+  versionBar('API Server Memory (mean)', '__measurements_tektonResultsApi_memory_mean', 'bytes', 0, 124, pw, ph,
+    description='Mean memory (RSS) of the tekton-results-api Pod. High memory may indicate query result caching or connection pool growth under Locust load.'),
+
+  // ── Pipeline Performance ───────────────────────────────────────
+  row('Pipeline Performance', 132),
+  versionBar('PipelineRun Duration (avg)', '__results_PipelineRuns_duration_avg', 's', 0, 133, pw, ph,
+    description='Average wall-clock time from PipelineRun creation to completion. Each pipeline has 5 tasks × 10 steps × 15 log lines. Includes scheduling, execution, and signing overhead.'),
+  versionBar('PipelineRun Succeeded', '__results_PipelineRuns_count_succeeded', 'none', 0, 141, pw, ph,
+    description='Total PipelineRuns that completed successfully. The test creates PRs at a constant rate with 30 concurrent; all should succeed.', agg='SUM'),
+
+  // ── Cluster & Infrastructure ───────────────────────────────────
+  row('Cluster & Infrastructure', 149),
+  versionBar('Cluster CPU', '__measurements_clusterCpuUsageSecondsTotalRate_mean', 'short', 0, 150, pw, ph,
+    description='Mean total cluster CPU usage rate (cores) across all nodes. Reflects the combined load of pipeline execution, signing, ingestion, and Locust testing.'),
+  versionBar('Cluster Memory', '__measurements_clusterMemoryUsageRssTotal_mean', 'bytes', 0, 158, pw, ph,
+    description='Mean total cluster RSS memory across all nodes during the test.'),
+
+  // ── etcd ───────────────────────────────────────────────────────
+  row('etcd', 166),
+  versionBar('etcd DB Size', '__measurements_etcdMvccDbTotalSizeInBytesAverage_mean', 'bytes', 0, 167, pw, ph,
+    description='Mean etcd MVCC database total size. Reflects Kubernetes object storage growth from PipelineRun/TaskRun creation.'),
+  versionBar('etcd Request Duration', '__measurements_etcdRequestDurationSecondsAverage_mean', 's', 0, 175, pw, ph,
+    description='Mean etcd request latency. High latency indicates etcd is under pressure from the volume of Kubernetes API operations.'),
+];
+
+dashboard.new('Results Version Comparison (v2)')
++ dashboard.withUid('Results_Version_Comparison_v2')
++ dashboard.withDescription('Daily side-by-side version comparison of Tekton Results ingestion, API performance, and component resource usage. Test ID 425.')
++ dashboard.time.withFrom('now-14d')
++ dashboard.time.withTo('now')
++ dashboard.withTimezone('utc')
++ dashboard.withRefresh('5m')
++ dashboard.withVariables([datasourceVar, versionVar])
++ dashboard.withPanels(allPanels)
++ dashboard.withEditable(true)
++ dashboard.withTags(['results', 'version-comparison', 'performance'])
++ dashboard.graphTooltip.withSharedTooltip()


### PR DESCRIPTION
## Summary

Add variant-specific comparison(v2) bar chart dashboards for pipelines, chains, and results, plus new Results trend and comparison dashboards. Refactor existing dashboards to use shared libraries and apply consistent visual polish.

### What changed

- **Shared libraries** (`src/lib/`): Extract duplicate code into `pipelines-common.libsonnet`, `chains-common.libsonnet`, and `results-common.libsonnet`.

- **v2 bar chart dashboards** (new): Daily version-comparison bar charts for pipelines, chains, and results.

- **Results dashboards** (new): Trend, comparison and v2 bar chart dashboards for Tekton Results (test 425) covering watcher ingestion, API load testing (/record, /records), component resource usage and pipeline performance.

- **Existing dashboard refactor**: Pipelines and chains trend/comparison dashboards now import from shared libs instead of duplicating SQL predicates. Visual polish applied: gradient fills, line width 2, point size 6, shared tooltips, clean legends.

- **build.sh**: Updated to build all 9 dashboards.

### Dashboard links

| Dashboard | Link |
|-----------|------|
| Pipelines Trend | [Pipelines_Performance](http://10.0.109.83:3000/d/Pipelines_Performance) |
| Pipelines Comparison | [Pipelines_Performance_Comparison](http://10.0.109.83:3000/d/Pipelines_Performance_Comparison) |
| Pipelines Comparison v2 Bar Chart | [Pipelines_Version_Comparison_v2](http://10.0.109.83:3000/d/Pipelines_Version_Comparison_v2) |
| Chains Trend | [Chains_Signing_Performance](http://10.0.109.83:3000/d/Chains_Signing_Performance) |
| Chains Comparison | [Chains_Signing_Performance_Comparison](http://10.0.109.83:3000/d/Chains_Signing_Performance_Comparison) |
| Chains Comparison v2 Bar Chart | [Chains_Version_Comparison_v2](http://10.0.109.83:3000/d/Chains_Version_Comparison_v2) |
| Results Trend | [Results_Performance](http://10.0.109.83:3000/d/Results_Performance) |
| Results Comparison | [Results_Comparison](http://10.0.109.83:3000/d/Results_Comparison) |
| Results Comparison v2 Bar Chart | [Results_Version_Comparison_v2](http://10.0.109.83:3000/d/Results_Version_Comparison_v2) |

