### PR TITLE
Use commit hash for git-resolver to enable resolver cache

### DIFF
--- a/tests/scaling-pipelines/scenario/git-resolver/pipeline.yaml.j2
+++ b/tests/scaling-pipelines/scenario/git-resolver/pipeline.yaml.j2
@@ -13,7 +13,7 @@ spec:
       - name: url
         value: https://github.com/openshift-pipelines/performance.git
       - name: revision
-        value: main
+        value: 3542fa90318b8e4649f722ae5ee5759e1b899557
       - name: pathInRepo
         value: tests/scaling-pipelines/scenario/git-resolver/task-multi-step/task-multi-step-{{ step_count }}.yaml
 


### PR DESCRIPTION
Pin the git-resolver revision to a specific commit SHA instead of 'main'. This allows the Tekton Git Resolver to use its local cache for repeated resolutions, since immutable content can be safely cached.